### PR TITLE
Add FastAPI app shell

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+FRONTEND_DIR = ROOT_DIR / "frontend"
+STATIC_DIR = FRONTEND_DIR / "static"
+TEMPLATES_DIR = FRONTEND_DIR / "templates"
+
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+
+
+def create_app() -> FastAPI:
+    """Create the FastAPI application."""
+    app = FastAPI(title="Pogodapp")
+    app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index(request: Request) -> HTMLResponse:
+        return templates.TemplateResponse(request=request, name="index.html")
+
+    return app
+
+
+app = create_app()

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -1,7 +1,73 @@
 :root {
+  color: #13222c;
   font-family: "Atkinson Hyperlegible", sans-serif;
+  background: linear-gradient(180deg, #f2efe6 0%, #dfeaf0 100%);
 }
 
 body {
   margin: 0;
+  min-height: 100vh;
+  background: transparent;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+.app-shell {
+  display: grid;
+  gap: 1.5rem;
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.intro,
+.panel {
+  border: 1px solid rgba(19, 34, 44, 0.12);
+  border-radius: 1rem;
+  background: rgba(255, 252, 247, 0.8);
+  box-shadow: 0 1rem 2.5rem rgba(19, 34, 44, 0.08);
+}
+
+.intro {
+  display: grid;
+  gap: 0.75rem;
+  padding: 2rem;
+}
+
+.eyebrow {
+  font-size: 0.875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #46606d;
+}
+
+.lede {
+  max-width: 42rem;
+  line-height: 1.6;
+}
+
+.panel {
+  display: grid;
+  gap: 0.5rem;
+  padding: 1.5rem;
+}
+
+.map-panel {
+  min-height: 18rem;
+}
+
+@media (min-width: 48rem) {
+  .app-shell {
+    grid-template-columns: minmax(18rem, 22rem) minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .intro {
+    grid-column: 1 / -1;
+  }
 }

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -7,9 +7,24 @@
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
-    <main>
-      <h1>Pogodapp</h1>
-      <p>Scaffold placeholder.</p>
+    <main class="app-shell">
+      <section class="intro">
+        <p class="eyebrow">Climate preference search</p>
+        <h1>Pogodapp</h1>
+        <p class="lede">
+          Describe an ideal climate profile, score places against long-term normals, and inspect the results on one map.
+        </p>
+      </section>
+
+      <section class="panel" aria-label="Controls placeholder">
+        <h2>Controls</h2>
+        <p>Preference controls will land here in the next issue.</p>
+      </section>
+
+      <section class="panel map-panel" aria-label="Map placeholder">
+        <h2>Map</h2>
+        <p>Map rendering is wired in as a static asset and ready for later data updates.</p>
+      </section>
     </main>
     <script src="/static/map.js"></script>
   </body>

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,2 +1,20 @@
-def test_smoke() -> None:
-    assert True
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_home_page_renders() -> None:
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "Pogodapp" in response.text
+    assert "Climate preference search" in response.text
+
+
+def test_static_files_are_served() -> None:
+    response = client.get("/static/styles.css")
+
+    assert response.status_code == 200
+    assert "font-family" in response.text


### PR DESCRIPTION
## Summary
- add a minimal FastAPI app factory that serves the Jinja home page and mounts static assets from the same process
- replace the placeholder screen with a simple single-route app shell for the upcoming controls and map work
- add smoke coverage for the rendered home page and static file serving

## Testing
- uv run ruff check .
- uv run ty check
- uv run pytest

closes #1