### PR TITLE
Define preference form contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Each grid cell is scored month-by-month, then combined into one annual score.
 - Temperature penalty is asymmetric: cold deviations and heat deviations use different slopes, with a comfort band around the ideal temperature
 - Rain penalty scales with precipitation and user sensitivity
 - Cloud penalty uses the agreed misery-style curve, harsher at high cover
+- The user-facing form contract uses `sun_preference`; later scoring maps that preference onto the cloud-cover signal
 - Final scores are normalized to the `0..1` range for map rendering
 
 ## Repository Layout

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,9 +1,17 @@
 from dataclasses import dataclass
 
+PREFERENCE_FIELD_NAMES: tuple[str, ...] = (
+    "ideal_temperature",
+    "cold_tolerance",
+    "heat_tolerance",
+    "rain_sensitivity",
+    "sun_preference",
+)
+
 
 @dataclass(frozen=True, slots=True)
 class PreferenceField:
-    """Default UI configuration for a single preference control."""
+    """Canonical UI contract for a single climate preference field."""
 
     name: str
     label: str
@@ -13,6 +21,9 @@ class PreferenceField:
     value: int
 
 
+# Higher sensitivity means a stronger score penalty.
+# `sun_preference` stays user-facing while later scoring maps it onto cloud-cover data.
+# Exact scoring curves stay unresolved until the scoring issue lands.
 DEFAULT_PREFERENCES: tuple[PreferenceField, ...] = (
     PreferenceField(
         name="ideal_temperature",
@@ -23,19 +34,35 @@ DEFAULT_PREFERENCES: tuple[PreferenceField, ...] = (
         value=22,
     ),
     PreferenceField(
-        name="rain_tolerance",
-        label="Rain tolerance",
+        name="cold_tolerance",
+        label="Cold tolerance",
         minimum=0,
-        maximum=100,
-        step=5,
-        value=35,
+        maximum=15,
+        step=1,
+        value=7,
     ),
     PreferenceField(
-        name="cloud_tolerance",
-        label="Cloud tolerance",
+        name="heat_tolerance",
+        label="Heat tolerance",
+        minimum=0,
+        maximum=15,
+        step=1,
+        value=5,
+    ),
+    PreferenceField(
+        name="rain_sensitivity",
+        label="Rain sensitivity",
         minimum=0,
         maximum=100,
         step=5,
-        value=40,
+        value=55,
+    ),
+    PreferenceField(
+        name="sun_preference",
+        label="Sun preference",
+        minimum=0,
+        maximum=100,
+        step=5,
+        value=60,
     ),
 )

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -26,6 +26,7 @@
               id="{{ preference.name }}"
               name="{{ preference.name }}"
               type="range"
+              data-field="{{ preference.name }}"
               min="{{ preference.minimum }}"
               max="{{ preference.maximum }}"
               step="{{ preference.step }}"

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from backend.config import DEFAULT_PREFERENCES
+from backend.config import DEFAULT_PREFERENCES, PREFERENCE_FIELD_NAMES
 from backend.main import app
 
 client = TestClient(app)
@@ -24,7 +24,24 @@ def test_home_page_uses_backend_default_preferences() -> None:
     for preference in DEFAULT_PREFERENCES:
         assert f'id="{preference.name}"' in response.text
         assert f'name="{preference.name}"' in response.text
+        assert f'data-field="{preference.name}"' in response.text
+        assert f'min="{preference.minimum}"' in response.text
+        assert f'max="{preference.maximum}"' in response.text
+        assert f'step="{preference.step}"' in response.text
         assert f'value="{preference.value}"' in response.text
+
+
+def test_preference_contract_matches_issue_scope() -> None:
+    expected_names = (
+        "ideal_temperature",
+        "cold_tolerance",
+        "heat_tolerance",
+        "rain_sensitivity",
+        "sun_preference",
+    )
+
+    assert expected_names == PREFERENCE_FIELD_NAMES
+    assert tuple(preference.name for preference in DEFAULT_PREFERENCES) == expected_names
 
 
 def test_static_files_are_served() -> None:


### PR DESCRIPTION
## Summary
- define the canonical preference field contract in backend config, including explicit field names, ranges, step sizes, and defaults
- split temperature into ideal, cold tolerance, and heat tolerance while renaming the cloud-facing control to the user-facing `sun_preference`
- document that `sun_preference` maps onto cloud-cover data later and verify the rendered form uses the backend contract consistently

Closes #3

## Testing
- uv run ruff check .
- uv run ty check
- uv run pytest
