### PR TITLE
Wire HTMX score requests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,11 +1,13 @@
 from pathlib import Path
+from typing import Annotated
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Form, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from backend.config import DEFAULT_PREFERENCES
+from backend.scoring import PreferenceInputs, ScorePoint, score_preferences
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
 FRONTEND_DIR = ROOT_DIR / "frontend"
@@ -32,6 +34,23 @@ def create_app() -> FastAPI:
             name="index.html",
             context=build_index_context(),
         )
+
+    @app.post("/score")
+    async def score(
+        ideal_temperature: Annotated[int, Form()],
+        cold_tolerance: Annotated[int, Form()],
+        heat_tolerance: Annotated[int, Form()],
+        rain_sensitivity: Annotated[int, Form()],
+        sun_preference: Annotated[int, Form()],
+    ) -> list[ScorePoint]:
+        preferences = PreferenceInputs(
+            ideal_temperature=ideal_temperature,
+            cold_tolerance=cold_tolerance,
+            heat_tolerance=heat_tolerance,
+            rain_sensitivity=rain_sensitivity,
+            sun_preference=sun_preference,
+        )
+        return score_preferences(preferences)
 
     return app
 

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from typing import TypedDict
+
+
+@dataclass(frozen=True, slots=True)
+class PreferenceInputs:
+    """Normalized form inputs passed into the scoring layer."""
+
+    ideal_temperature: int
+    cold_tolerance: int
+    heat_tolerance: int
+    rain_sensitivity: int
+    sun_preference: int
+
+
+class ScorePoint(TypedDict):
+    """JSON score payload returned to the frontend."""
+
+    lat: float
+    lon: float
+    score: float
+
+
+def score_preferences(preferences: PreferenceInputs) -> list[ScorePoint]:
+    """Return a placeholder score payload until climate scoring lands."""
+    _ = preferences
+    return []

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -18,7 +18,12 @@
 
       <section class="panel" aria-label="Controls area">
         <h2>Controls</h2>
-        <form id="preferences" hx-post="/score" hx-trigger="change delay:200ms">
+        <form
+          id="preferences"
+          hx-post="/score"
+          hx-trigger="input changed delay:300ms"
+          hx-swap="none"
+        >
           {% for preference in preferences %}
           <label class="control" for="{{ preference.name }}">
             <span>{{ preference.label }}</span>

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -12,7 +12,9 @@ def test_home_page_renders() -> None:
     assert response.status_code == 200
     assert "Pogodapp" in response.text
     assert "Climate preference search" in response.text
-    assert '<form id="preferences" hx-post="/score" hx-trigger="change delay:200ms">' in response.text
+    assert 'hx-post="/score"' in response.text
+    assert 'hx-trigger="input changed delay:300ms"' in response.text
+    assert 'hx-swap="none"' in response.text
     assert '<div id="map" role="img" aria-label="Map results placeholder"></div>' in response.text
 
 
@@ -49,3 +51,21 @@ def test_static_files_are_served() -> None:
 
     assert response.status_code == 200
     assert "font-family" in response.text
+
+
+def test_score_endpoint_accepts_form_encoded_preferences() -> None:
+    response = client.post(
+        "/score",
+        data={
+            "ideal_temperature": "22",
+            "cold_tolerance": "7",
+            "heat_tolerance": "5",
+            "rain_sensitivity": "55",
+            "sun_preference": "60",
+        },
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json() == []


### PR DESCRIPTION
## Summary
- wire the preference form to post debounced HTMX requests to `POST /score` using standard form fields
- add a thin FastAPI `POST /score` route and scoring stub boundary so transport is in place before real scoring lands
- keep the JSON response safe for HTMX by using `hx-swap="none"`, which avoids trying to swap the raw JSON into the page while still allowing later `htmx:afterRequest` handling

Closes #4

## Verification
- `POST /score` accepts form-encoded fields compatible with FastAPI `Form()` parameters
- the page uses `hx-trigger="input changed delay:300ms"` for debounced updates
- `hx-swap="none"` is valid HTMX behavior for ignoring response content while keeping the request lifecycle events

## Testing
- uv run ruff check .
- uv run ty check
- uv run pytest
