### PR TITLE
Return stub score payload

### DIFF
--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -13,6 +13,17 @@ class PreferenceInputs:
     sun_preference: int
 
 
+@dataclass(frozen=True, slots=True)
+class StubClimateCell:
+    """Deterministic placeholder climate data for one grid cell."""
+
+    lat: float
+    lon: float
+    temperature: float
+    rain_index: int
+    sun_index: int
+
+
 class ScorePoint(TypedDict):
     """JSON score payload returned to the frontend."""
 
@@ -21,7 +32,46 @@ class ScorePoint(TypedDict):
     score: float
 
 
+STUB_CLIMATE_CELLS: tuple[StubClimateCell, ...] = (
+    StubClimateCell(lat=37.5, lon=-122.0, temperature=17.0, rain_index=30, sun_index=72),
+    StubClimateCell(lat=41.9, lon=12.5, temperature=19.0, rain_index=42, sun_index=68),
+    StubClimateCell(lat=-33.9, lon=18.4, temperature=21.0, rain_index=28, sun_index=80),
+    StubClimateCell(lat=35.7, lon=139.7, temperature=16.0, rain_index=58, sun_index=54),
+    StubClimateCell(lat=-22.9, lon=-43.2, temperature=25.0, rain_index=63, sun_index=77),
+)
+
+
+def clamp_score(value: float) -> float:
+    """Keep scores in the API's normalized range."""
+    return max(0.0, min(1.0, value))
+
+
+def temperature_score(cell: StubClimateCell, preferences: PreferenceInputs) -> float:
+    """Approximate asymmetric temperature fit for stub data."""
+    delta = cell.temperature - preferences.ideal_temperature
+    tolerance = preferences.heat_tolerance if delta >= 0 else preferences.cold_tolerance
+    scale = max(tolerance, 1)
+    return clamp_score(1 - abs(delta) / scale)
+
+
+def sensitivity_score(observed: int, preferred: int) -> float:
+    """Approximate fit for 0..100 sensitivity-style controls."""
+    return clamp_score(1 - abs(observed - preferred) / 100)
+
+
 def score_preferences(preferences: PreferenceInputs) -> list[ScorePoint]:
-    """Return a placeholder score payload until climate scoring lands."""
-    _ = preferences
-    return []
+    """Return deterministic placeholder scores until real climate scoring lands."""
+    scores: list[ScorePoint] = []
+
+    for cell in STUB_CLIMATE_CELLS:
+        score = clamp_score(
+            (
+                temperature_score(cell, preferences)
+                + sensitivity_score(cell.rain_index, preferences.rain_sensitivity)
+                + sensitivity_score(cell.sun_index, preferences.sun_preference)
+            )
+            / 3
+        )
+        scores.append({"lat": cell.lat, "lon": cell.lon, "score": score})
+
+    return scores

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -68,4 +68,30 @@ def test_score_endpoint_accepts_form_encoded_preferences() -> None:
 
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/json")
-    assert response.json() == []
+    payload = response.json()
+
+    assert isinstance(payload, list)
+    assert payload
+
+    for item in payload:
+        assert set(item) == {"lat", "lon", "score"}
+        assert isinstance(item["lat"], float)
+        assert isinstance(item["lon"], float)
+        assert 0 <= item["score"] <= 1
+
+
+def test_score_endpoint_is_deterministic_for_the_same_preferences() -> None:
+    form_data = {
+        "ideal_temperature": "22",
+        "cold_tolerance": "7",
+        "heat_tolerance": "5",
+        "rain_sensitivity": "55",
+        "sun_preference": "60",
+    }
+
+    first_response = client.post("/score", data=form_data)
+    second_response = client.post("/score", data=form_data)
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert first_response.json() == second_response.json()


### PR DESCRIPTION
## Summary
- replace the empty scoring stub with deterministic placeholder grid cells that return real `{lat, lon, score}` JSON rows
- keep the `/score` route thin by leaving all placeholder scoring logic inside `backend/scoring.py`
- verify the stub payload shape, normalization, and deterministic behavior so later frontend wiring can build against a stable contract

Closes #5

## Testing
- uv run ruff check .
- uv run ty check
- uv run pytest
