### PR TITLE
Implement initial MapLibre and Protomaps map rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Pogodapp
 
-Pogodapp is a climate preference search tool, not a weather app. The user describes an ideal climate profile and the app scores places around the world against long-term climate normals, then shows the result as an interactive map heatmap.
+Pogodapp is a climate preference search tool, not a weather app. The user describes an ideal climate profile and the app scores places around the world against long-term climate normals, then shows the result as an interactive world map.
 
 ## Goal
 
 - Let the user tune climate preferences with simple controls
 - Score global grid cells against those preferences
-- Render good matches brightly and bad matches dimly on a world map
+- Render scored matches on a world map so stronger results stand out clearly
 
 ## Stack
 
@@ -28,6 +28,8 @@ Pogodapp is a climate preference search tool, not a weather app. The user descri
 - HTMX submits form changes to `/score`
 - `htmx:afterRequest` bridges the response into the map update path
 - `frontend/static/map.js` stays focused on rendering, not networking
+- The current map uses MapLibre GL with the PMTiles browser protocol and Protomaps basemap layers loaded from public CDN/asset hosts
+- If those external map assets are blocked or unavailable, the map falls back to an in-page failure message while the textual score list still renders
 - DuckDB is the only runtime data store
 
 ## Data Model Direction
@@ -48,6 +50,7 @@ Each grid cell is scored month-by-month, then combined into one annual score.
 - `sun_preference` currently uses a symmetric preference-fit curve against the stub sun signal
 - The user-facing form contract uses `sun_preference`; later scoring maps that preference onto the cloud-cover signal
 - Final scores are normalized to the `0..1` range for map rendering
+- The current prototype renders scores as colored circle markers with larger, warmer markers indicating better matches
 
 ## Repository Layout
 

--- a/frontend/static/map.js
+++ b/frontend/static/map.js
@@ -1,35 +1,193 @@
 "use strict";
 
-// Render parsed `/score` payload items and fall back to an empty state for invalid results.
-window.renderScores = function renderScores(scores) {
-  const map = document.getElementById("map");
+const PROTOMAPS_PM_TILES_URL = "pmtiles://https://build.protomaps.com/20260330.pmtiles";
+const PROTOMAPS_ATTRIBUTION =
+  '<a href="https://protomaps.com">Protomaps</a> © <a href="https://openstreetmap.org/copyright">OpenStreetMap</a>';
+const SCORE_SOURCE_ID = "scores";
+const SCORE_LAYER_ID = "scores-circles";
+const EMPTY_SCORE_COLLECTION = { type: "FeatureCollection", features: [] };
 
-  if (!map) {
+let map;
+let pendingScores = EMPTY_SCORE_COLLECTION;
+let pmtilesProtocol;
+
+function setMapStatus(message) {
+  const status = document.getElementById("map-status");
+
+  if (status) {
+    status.textContent = message;
+  }
+}
+
+function renderScoreList(collection) {
+  const results = document.getElementById("score-results-list");
+
+  if (!results) {
     return;
   }
 
-  map.replaceChildren();
+  results.replaceChildren();
 
-  if (!Array.isArray(scores) || scores.length === 0) {
-    const emptyState = document.createElement("p");
-    emptyState.textContent = "No scored locations available.";
-    map.append(emptyState);
-    return;
-  }
-
-  const list = document.createElement("ol");
-  list.className = "map-results";
-
-  for (const { lat, lon, score } of scores) {
+  if (collection.features.length === 0) {
     const item = document.createElement("li");
-    const scoreLabel = document.createElement("strong");
-    const coordinateLabel = document.createElement("span");
-
-    scoreLabel.textContent = `${Math.round(score * 100)}%`;
-    coordinateLabel.textContent = `${lat}, ${lon}`;
-    item.append(scoreLabel, coordinateLabel);
-    list.append(item);
+    item.textContent = "No scored locations available yet.";
+    results.append(item);
+    return;
   }
 
-  map.append(list);
+  for (const feature of collection.features) {
+    const item = document.createElement("li");
+    const [lon, lat] = feature.geometry.coordinates;
+    const score = feature.properties.score;
+
+    item.textContent = `${Math.round(score * 100)}% match at ${lat}, ${lon}`;
+    results.append(item);
+  }
+}
+
+function toScoreFeatureCollection(scores) {
+  if (!Array.isArray(scores)) {
+    return EMPTY_SCORE_COLLECTION;
+  }
+
+  const features = [];
+
+  for (const point of scores) {
+    if (
+      typeof point?.lat !== "number" ||
+      typeof point?.lon !== "number" ||
+      typeof point?.score !== "number"
+    ) {
+      continue;
+    }
+
+    features.push({
+      type: "Feature",
+      geometry: {
+        type: "Point",
+        coordinates: [point.lon, point.lat],
+      },
+      properties: {
+        score: point.score,
+        label: `${Math.round(point.score * 100)}%`,
+      },
+    });
+  }
+
+  return { type: "FeatureCollection", features };
+}
+
+function applyScores(collection) {
+  pendingScores = collection;
+  renderScoreList(collection);
+
+  if (collection.features.length === 0) {
+    setMapStatus("No scored locations available.");
+  } else {
+    setMapStatus(`${collection.features.length} scored locations rendered on the map.`);
+  }
+
+  if (!map || !map.isStyleLoaded()) {
+    return;
+  }
+
+  const source = map.getSource(SCORE_SOURCE_ID);
+
+  if (source) {
+    source.setData(collection);
+  }
+}
+
+function initializeMap() {
+  const mapRoot = document.getElementById("map");
+
+  if (!mapRoot || map) {
+    return;
+  }
+
+  if (!window.maplibregl || !window.pmtiles || !window.basemaps) {
+    mapRoot.textContent = "Map libraries failed to load.";
+    setMapStatus("Map libraries failed to load.");
+    return;
+  }
+
+  if (!pmtilesProtocol) {
+    pmtilesProtocol = new window.pmtiles.Protocol();
+    window.maplibregl.addProtocol("pmtiles", pmtilesProtocol.tile);
+  }
+
+  map = new window.maplibregl.Map({
+    container: mapRoot,
+    style: {
+      version: 8,
+      glyphs: "https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf",
+      sprite: "https://protomaps.github.io/basemaps-assets/sprites/v4/light",
+      sources: {
+        protomaps: {
+          type: "vector",
+          url: PROTOMAPS_PM_TILES_URL,
+          attribution: PROTOMAPS_ATTRIBUTION,
+        },
+      },
+      layers: window.basemaps.layers("protomaps", window.basemaps.namedFlavor("light"), {
+        lang: "en",
+      }),
+    },
+    center: [12, 20],
+    zoom: 1.4,
+  });
+
+  map.addControl(new window.maplibregl.NavigationControl({ showCompass: false }), "top-right");
+
+  map.on("load", () => {
+    map.addSource(SCORE_SOURCE_ID, {
+      type: "geojson",
+      data: pendingScores,
+    });
+
+    map.addLayer({
+      id: SCORE_LAYER_ID,
+      type: "circle",
+      source: SCORE_SOURCE_ID,
+      paint: {
+        "circle-color": [
+          "interpolate",
+          ["linear"],
+          ["get", "score"],
+          0,
+          "#355c7d",
+          0.5,
+          "#f8b65a",
+          1,
+          "#ea5f89",
+        ],
+        "circle-opacity": 0.82,
+        "circle-radius": [
+          "interpolate",
+          ["linear"],
+          ["get", "score"],
+          0,
+          4,
+          1,
+          13,
+        ],
+        "circle-stroke-color": "#fffaf3",
+        "circle-stroke-width": 1.5,
+      },
+    });
+
+    applyScores(pendingScores);
+  });
+}
+
+window.renderScores = function renderScores(scores) {
+  applyScores(toScoreFeatureCollection(scores));
 };
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initializeMap, { once: true });
+} else {
+  initializeMap();
+}
+
+renderScoreList(EMPTY_SCORE_COLLECTION);

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -10,6 +10,18 @@ body {
   background: transparent;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 h1,
 h2,
 p {
@@ -77,13 +89,74 @@ p {
 }
 
 .map-panel {
-  min-height: 18rem;
+  min-height: 24rem;
+}
+
+.map-description {
+  color: #46606d;
+  line-height: 1.5;
+}
+
+.map-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.map-legend__title {
+  font-weight: 700;
+}
+
+.map-legend__swatch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  color: #fffaf3;
+  font-size: 0.875rem;
+}
+
+.map-legend__swatch--low {
+  background: #355c7d;
+}
+
+.map-legend__swatch--mid {
+  background: #f8b65a;
+  color: #13222c;
+}
+
+.map-legend__swatch--high {
+  background: #ea5f89;
+}
+
+.score-results {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.score-results h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+#score-results-list {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+  padding-left: 1.25rem;
 }
 
 #map {
-  min-height: 14rem;
+  min-height: 20rem;
   border-radius: 0.75rem;
+  overflow: hidden;
   background: linear-gradient(135deg, rgba(70, 96, 109, 0.12), rgba(19, 34, 44, 0.04));
+}
+
+#map .maplibregl-map {
+  min-height: 20rem;
 }
 
 @media (min-width: 48rem) {

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -4,6 +4,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Pogodapp</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/maplibre-gl@5.6.2/dist/maplibre-gl.css"
+    />
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
@@ -45,10 +49,27 @@
 
       <section class="panel map-panel" aria-label="Map container">
         <h2>Map</h2>
-        <div id="map" role="img" aria-label="Map results placeholder"></div>
+        <p id="map-status" class="visually-hidden" role="status" aria-live="polite"></p>
+        <p id="map-description" class="map-description">
+          Interactive world map of scored climate matches. Larger, warmer markers indicate higher scores.
+        </p>
+        <div id="map-legend" class="map-legend" aria-label="Map legend">
+          <span class="map-legend__title">Score</span>
+          <span class="map-legend__swatch map-legend__swatch--low">Low</span>
+          <span class="map-legend__swatch map-legend__swatch--mid">Medium</span>
+          <span class="map-legend__swatch map-legend__swatch--high">High</span>
+        </div>
+        <div id="map" role="region" aria-label="Interactive climate score map" aria-describedby="map-description map-legend map-status"></div>
+        <div class="score-results" aria-labelledby="score-results-title">
+          <h3 id="score-results-title">Scored locations</h3>
+          <ol id="score-results-list"></ol>
+        </div>
       </section>
     </main>
     <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+    <script src="https://unpkg.com/maplibre-gl@5.6.2/dist/maplibre-gl.js"></script>
+    <script src="https://unpkg.com/pmtiles@4.3.0/dist/pmtiles.js"></script>
+    <script src="https://unpkg.com/@protomaps/basemaps@5.0.0/dist/basemaps.js"></script>
     <script src="/static/map.js"></script>
     <script>
       document.addEventListener("DOMContentLoaded", () => {

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -16,7 +16,18 @@ def test_home_page_renders() -> None:
     assert 'hx-post="/score"' in response.text
     assert 'hx-trigger="input changed delay:300ms"' in response.text
     assert 'hx-swap="none"' in response.text
-    assert '<div id="map" role="img" aria-label="Map results placeholder"></div>' in response.text
+    assert 'id="map-description"' in response.text
+    assert 'id="map-status"' in response.text
+    assert 'id="map-legend"' in response.text
+    assert (
+        'id="map" role="region" aria-label="Interactive climate score map" aria-describedby="map-description map-legend map-status"'
+        in response.text
+    )
+    assert 'id="score-results-list"' in response.text
+    assert "maplibre-gl.css" in response.text
+    assert "maplibre-gl.js" in response.text
+    assert "pmtiles.js" in response.text
+    assert "basemaps.js" in response.text
 
 
 def test_home_page_uses_backend_default_preferences() -> None:
@@ -62,6 +73,20 @@ def test_static_files_are_served() -> None:
 
     assert response.status_code == 200
     assert "font-family" in response.text
+
+
+def test_map_script_initializes_maplibre_score_layer() -> None:
+    response = client.get("/static/map.js")
+
+    assert response.status_code == 200
+    assert "new window.maplibregl.Map" in response.text
+    assert "map.addSource(SCORE_SOURCE_ID" in response.text
+    assert "map.addLayer({" in response.text
+    assert 'window.maplibregl.addProtocol("pmtiles"' in response.text
+    assert 'window.basemaps.layers("protomaps"' in response.text
+    assert "url: PROTOMAPS_PM_TILES_URL" in response.text
+    assert "renderScoreList(collection);" in response.text
+    assert 'setMapStatus("Map libraries failed to load.");' in response.text
 
 
 def test_score_endpoint_accepts_form_encoded_preferences() -> None:


### PR DESCRIPTION
## Summary
- implement the initial MapLibre and Protomaps PMTiles rendering path for scored climate results without moving request logic into `map.js`
- add accessible map support with a description, live status region, legend, and synchronized textual score list alongside the interactive map
- update route-level tests and README copy to reflect the live map integration, current marker-based visualization, and external map asset dependency

## Testing
- `uv run pytest tests/test_app_shell.py`

## Follow-up Note
- the current basemap points at public Protomaps CDN/build assets as a prototype path; longer-term hosting/config hardening should be handled separately

Closes #7
