### PR TITLE
Implement climate scoring model

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Pogodapp is a climate preference search tool, not a weather app. The user descri
 Each grid cell is scored month-by-month, then combined into one annual score.
 
 - Temperature penalty is asymmetric: cold deviations and heat deviations use different slopes, with a comfort band around the ideal temperature
-- Rain is one-sided: higher `rain_sensitivity` increases penalties for wetter cells without rewarding rain
-- `sun_preference` currently uses a symmetric preference-fit curve against the stub sun signal
-- The user-facing form contract uses `sun_preference`; later scoring maps that preference onto the cloud-cover signal
+- Rain is one-sided: higher `rain_sensitivity` increases penalties for wetter months without rewarding rain
+- `sun_preference` maps onto a cloud-cover tolerance threshold and then applies a one-sided misery-style cloud penalty
+- The stub scorer now uses one grid-cell record with 12 monthly values per climate signal and averages monthly composite scores into one annual score; DuckDB-backed data still lands in later issues
 - Final scores are normalized to the `0..1` range for map rendering
 - The current prototype renders scores as colored circle markers with larger, warmer markers indicating better matches
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -22,8 +22,8 @@ class PreferenceField:
 
 
 # Higher sensitivity means a stronger score penalty.
-# `sun_preference` stays user-facing while later scoring maps it onto cloud-cover data.
-# Exact scoring curves stay unresolved until the scoring issue lands.
+# `sun_preference` stays user-facing even though scoring already maps it onto cloud-cover tolerance.
+# These ranges define the UI and `/score` contract; curve tuning can still evolve independently.
 DEFAULT_PREFERENCES: tuple[PreferenceField, ...] = (
     PreferenceField(
         name="ideal_temperature",

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -3,6 +3,13 @@ from typing import TypedDict
 
 from pydantic import BaseModel, Field
 
+MONTHS_PER_YEAR = 12
+TEMPERATURE_COMFORT_BAND_C = 1.5
+TEMPERATURE_SLOPE_BASE_C = 6.0
+SATURATING_MONTHLY_RAIN_MM = 300.0
+MAX_TOLERATED_CLOUD_COVER = 85.0
+MIN_TOLERATED_CLOUD_COVER = 15.0
+
 
 class PreferenceInputs(BaseModel):
     """Validated `/score` form inputs before FastAPI hands them to scoring."""
@@ -15,14 +22,28 @@ class PreferenceInputs(BaseModel):
 
 
 @dataclass(frozen=True, slots=True)
-class StubClimateCell:
-    """Deterministic placeholder climate data for one grid cell."""
+class ClimateCell:
+    """Monthly climate normals for one scored grid cell."""
 
     lat: float
     lon: float
-    temperature: float
-    rain_index: int
-    sun_index: int
+    temperature_c: tuple[float, ...]
+    precipitation_mm: tuple[float, ...]
+    cloud_cover_pct: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        """Reject incomplete monthly rows before they reach scoring code."""
+        if len(self.temperature_c) != MONTHS_PER_YEAR:
+            msg = "temperature_c must contain 12 monthly values"
+            raise ValueError(msg)
+
+        if len(self.precipitation_mm) != MONTHS_PER_YEAR:
+            msg = "precipitation_mm must contain 12 monthly values"
+            raise ValueError(msg)
+
+        if len(self.cloud_cover_pct) != MONTHS_PER_YEAR:
+            msg = "cloud_cover_pct must contain 12 monthly values"
+            raise ValueError(msg)
 
 
 class ScorePoint(TypedDict):
@@ -33,12 +54,42 @@ class ScorePoint(TypedDict):
     score: float
 
 
-STUB_CLIMATE_CELLS: tuple[StubClimateCell, ...] = (
-    StubClimateCell(lat=37.5, lon=-122.0, temperature=17.0, rain_index=30, sun_index=72),
-    StubClimateCell(lat=41.9, lon=12.5, temperature=19.0, rain_index=42, sun_index=68),
-    StubClimateCell(lat=-33.9, lon=18.4, temperature=21.0, rain_index=28, sun_index=80),
-    StubClimateCell(lat=35.7, lon=139.7, temperature=16.0, rain_index=58, sun_index=54),
-    StubClimateCell(lat=-22.9, lon=-43.2, temperature=25.0, rain_index=63, sun_index=77),
+STUB_CLIMATE_CELLS: tuple[ClimateCell, ...] = (
+    ClimateCell(
+        lat=37.5,
+        lon=-122.0,
+        temperature_c=(11.0, 12.0, 13.0, 14.0, 16.0, 18.0, 19.0, 20.0, 20.0, 18.0, 15.0, 12.0),
+        precipitation_mm=(110.0, 90.0, 70.0, 35.0, 15.0, 5.0, 1.0, 2.0, 8.0, 30.0, 70.0, 100.0),
+        cloud_cover_pct=(60, 55, 50, 40, 30, 20, 15, 15, 20, 30, 45, 55),
+    ),
+    ClimateCell(
+        lat=41.9,
+        lon=12.5,
+        temperature_c=(8.0, 9.0, 12.0, 15.0, 19.0, 23.0, 26.0, 26.0, 23.0, 18.0, 13.0, 9.0),
+        precipitation_mm=(80.0, 70.0, 60.0, 65.0, 45.0, 30.0, 20.0, 25.0, 70.0, 105.0, 115.0, 95.0),
+        cloud_cover_pct=(55, 50, 45, 40, 30, 20, 15, 15, 25, 35, 50, 55),
+    ),
+    ClimateCell(
+        lat=-33.9,
+        lon=18.4,
+        temperature_c=(21.0, 21.0, 20.0, 18.0, 16.0, 14.0, 13.0, 14.0, 15.0, 17.0, 18.0, 20.0),
+        precipitation_mm=(15.0, 18.0, 20.0, 35.0, 75.0, 95.0, 110.0, 90.0, 45.0, 30.0, 20.0, 15.0),
+        cloud_cover_pct=(20, 22, 28, 35, 45, 55, 60, 58, 45, 35, 28, 22),
+    ),
+    ClimateCell(
+        lat=35.7,
+        lon=139.7,
+        temperature_c=(6.0, 7.0, 10.0, 15.0, 19.0, 22.0, 26.0, 28.0, 24.0, 18.0, 13.0, 8.0),
+        precipitation_mm=(55.0, 60.0, 115.0, 125.0, 135.0, 160.0, 155.0, 170.0, 210.0, 195.0, 95.0, 55.0),
+        cloud_cover_pct=(45, 45, 50, 55, 60, 70, 75, 70, 65, 55, 45, 40),
+    ),
+    ClimateCell(
+        lat=-22.9,
+        lon=-43.2,
+        temperature_c=(27.0, 28.0, 27.0, 26.0, 24.0, 22.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0),
+        precipitation_mm=(175.0, 160.0, 180.0, 140.0, 110.0, 90.0, 75.0, 70.0, 110.0, 130.0, 145.0, 165.0),
+        cloud_cover_pct=(40, 38, 42, 45, 50, 55, 52, 48, 45, 42, 40, 38),
+    ),
 )
 
 
@@ -47,38 +98,60 @@ def clamp_score(value: float) -> float:
     return max(0.0, min(1.0, value))
 
 
-def temperature_score(cell: StubClimateCell, preferences: PreferenceInputs) -> float:
-    """Use cold vs. heat tolerance based on which side of the ideal a cell falls."""
-    delta = cell.temperature - preferences.ideal_temperature
+def temperature_score(observed_temperature_c: float, preferences: PreferenceInputs) -> float:
+    """Apply a comfort band around the ideal and separate cold vs. heat slopes outside it."""
+    delta = observed_temperature_c - preferences.ideal_temperature
+    distance_from_band = max(abs(delta) - TEMPERATURE_COMFORT_BAND_C, 0.0)
+
+    if distance_from_band == 0:
+        return 1.0
+
     tolerance = preferences.heat_tolerance if delta >= 0 else preferences.cold_tolerance
-    # Zero tolerance still means an exact-match preference, not a division error.
-    scale = max(tolerance, 1)
-    return clamp_score(1 - abs(delta) / scale)
+    slope_span = TEMPERATURE_SLOPE_BASE_C + tolerance
+    return clamp_score(1 - distance_from_band / slope_span)
 
 
-def rain_score(observed: int, sensitivity: int) -> float:
-    """Rain is one-sided: higher sensitivity should only penalize wetter cells more."""
-    return clamp_score(1 - (observed / 100) * (sensitivity / 100))
+def rain_score(monthly_precipitation_mm: float, sensitivity: int) -> float:
+    """Penalize wetter months without ever rewarding rain."""
+    precipitation_ratio = monthly_precipitation_mm / SATURATING_MONTHLY_RAIN_MM
+    return clamp_score(1 - precipitation_ratio * (sensitivity / 100))
 
 
-def preference_score(observed: int, preferred: int) -> float:
-    """Symmetric 0..100 distance score for preference-style controls."""
-    return clamp_score(1 - abs(observed - preferred) / 100)
+def cloud_score(monthly_cloud_cover_pct: int, sun_preference: int) -> float:
+    """Treat cloud as a misery-style penalty with a preference-dependent tolerance threshold."""
+    tolerated_cloud_cover = MAX_TOLERATED_CLOUD_COVER - (
+        (MAX_TOLERATED_CLOUD_COVER - MIN_TOLERATED_CLOUD_COVER) * (sun_preference / 100)
+    )
+
+    if monthly_cloud_cover_pct <= tolerated_cloud_cover:
+        return 1.0
+
+    excess_ratio = (monthly_cloud_cover_pct - tolerated_cloud_cover) / (100 - tolerated_cloud_cover)
+    return clamp_score(1 - excess_ratio**2)
+
+
+def monthly_score(cell: ClimateCell, month_index: int, preferences: PreferenceInputs) -> float:
+    """Combine the three monthly climate signals into one monthly fit score."""
+    return (
+        temperature_score(cell.temperature_c[month_index], preferences)
+        + rain_score(cell.precipitation_mm[month_index], preferences.rain_sensitivity)
+        + cloud_score(cell.cloud_cover_pct[month_index], preferences.sun_preference)
+    ) / 3
+
+
+def annual_score(cell: ClimateCell, preferences: PreferenceInputs) -> float:
+    """Average monthly scores into one normalized annual score."""
+    score_total = sum(monthly_score(cell, month_index, preferences) for month_index in range(MONTHS_PER_YEAR))
+    return clamp_score(score_total / MONTHS_PER_YEAR)
 
 
 def score_preferences(preferences: PreferenceInputs) -> list[ScorePoint]:
-    """Return deterministic placeholder scores until real climate scoring lands."""
-    scores: list[ScorePoint] = []
-
-    for cell in STUB_CLIMATE_CELLS:
-        score = clamp_score(
-            (
-                temperature_score(cell, preferences)
-                + rain_score(cell.rain_index, preferences.rain_sensitivity)
-                + preference_score(cell.sun_index, preferences.sun_preference)
-            )
-            / 3
-        )
-        scores.append({"lat": cell.lat, "lon": cell.lon, "score": score})
-
-    return scores
+    """Score every stub climate row until the DuckDB adapter lands."""
+    return [
+        {
+            "lat": cell.lat,
+            "lon": cell.lon,
+            "score": annual_score(cell, preferences),
+        }
+        for cell in STUB_CLIMATE_CELLS
+    ]

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,135 @@
+import pytest
+
+from backend.scoring import ClimateCell, PreferenceInputs, annual_score, cloud_score, rain_score, temperature_score
+
+
+def test_temperature_score_keeps_the_comfort_band_at_full_score() -> None:
+    preferences = PreferenceInputs(
+        ideal_temperature=22,
+        cold_tolerance=4,
+        heat_tolerance=6,
+        rain_sensitivity=50,
+        sun_preference=60,
+    )
+
+    assert temperature_score(22.0, preferences) == 1.0
+    assert temperature_score(23.5, preferences) == 1.0
+    assert temperature_score(20.5, preferences) == 1.0
+
+
+def test_temperature_score_uses_cold_and_heat_tolerances_as_separate_slopes() -> None:
+    preferences = PreferenceInputs(
+        ideal_temperature=22,
+        cold_tolerance=2,
+        heat_tolerance=10,
+        rain_sensitivity=50,
+        sun_preference=60,
+    )
+
+    assert temperature_score(15.0, preferences) < temperature_score(29.0, preferences)
+
+
+def test_temperature_score_uses_the_configured_band_and_slope_width() -> None:
+    preferences = PreferenceInputs(
+        ideal_temperature=22,
+        cold_tolerance=4,
+        heat_tolerance=6,
+        rain_sensitivity=50,
+        sun_preference=60,
+    )
+
+    assert temperature_score(24.0, preferences) == pytest.approx(1 - (0.5 / 12))
+    assert temperature_score(20.0, preferences) == pytest.approx(1 - (0.5 / 10))
+
+
+def test_temperature_score_with_zero_tolerance_still_uses_base_slope() -> None:
+    preferences = PreferenceInputs(
+        ideal_temperature=22,
+        cold_tolerance=0,
+        heat_tolerance=0,
+        rain_sensitivity=50,
+        sun_preference=60,
+    )
+
+    assert temperature_score(24.0, preferences) == pytest.approx(1 - (0.5 / 6))
+
+
+def test_cloud_score_penalizes_overcast_months_more_for_sun_seekers() -> None:
+    assert cloud_score(40, sun_preference=20) == 1.0
+    assert cloud_score(40, sun_preference=90) < 1.0
+    assert cloud_score(90, sun_preference=90) < cloud_score(60, sun_preference=90)
+
+
+def test_cloud_score_stays_perfect_at_the_tolerance_threshold_and_saturates_at_full_overcast() -> None:
+    assert cloud_score(22, sun_preference=90) == 1.0
+    assert cloud_score(100, sun_preference=90) == 0.0
+    assert cloud_score(61, sun_preference=90) == pytest.approx(0.75)
+
+
+def test_rain_score_respects_zero_sensitivity_and_saturation_point() -> None:
+    assert rain_score(150.0, sensitivity=0) == 1.0
+    assert rain_score(150.0, sensitivity=50) == pytest.approx(0.75)
+    assert rain_score(300.0, sensitivity=100) == 0.0
+    assert rain_score(450.0, sensitivity=100) == 0.0
+
+
+def test_annual_score_stays_normalized_for_extreme_climate_rows() -> None:
+    extreme_cell = ClimateCell(
+        lat=0.0,
+        lon=0.0,
+        temperature_c=(50.0,) * 12,
+        precipitation_mm=(400.0,) * 12,
+        cloud_cover_pct=(100,) * 12,
+    )
+    preferences = PreferenceInputs(
+        ideal_temperature=-10,
+        cold_tolerance=0,
+        heat_tolerance=0,
+        rain_sensitivity=100,
+        sun_preference=100,
+    )
+
+    assert annual_score(extreme_cell, preferences) == 0.0
+
+
+def test_annual_score_averages_monthly_scores_over_twelve_months() -> None:
+    mostly_perfect_cell = ClimateCell(
+        lat=0.0,
+        lon=0.0,
+        temperature_c=(22.0,) * 11 + (50.0,),
+        precipitation_mm=(0.0,) * 11 + (300.0,),
+        cloud_cover_pct=(15,) * 11 + (100,),
+    )
+    preferences = PreferenceInputs(
+        ideal_temperature=22,
+        cold_tolerance=0,
+        heat_tolerance=0,
+        rain_sensitivity=100,
+        sun_preference=100,
+    )
+
+    assert annual_score(mostly_perfect_cell, preferences) == pytest.approx(11 / 12)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "temperature_c", "precipitation_mm", "cloud_cover_pct"),
+    [
+        ("temperature_c", (20.0,) * 11, (50.0,) * 12, (30,) * 12),
+        ("precipitation_mm", (20.0,) * 12, (50.0,) * 11, (30,) * 12),
+        ("cloud_cover_pct", (20.0,) * 12, (50.0,) * 12, (30,) * 11),
+    ],
+)
+def test_climate_cell_requires_exactly_twelve_months_per_signal(
+    field_name: str,
+    temperature_c: tuple[float, ...],
+    precipitation_mm: tuple[float, ...],
+    cloud_cover_pct: tuple[int, ...],
+) -> None:
+    with pytest.raises(ValueError, match=field_name):
+        ClimateCell(
+            lat=0.0,
+            lon=0.0,
+            temperature_c=temperature_c,
+            precipitation_mm=precipitation_mm,
+            cloud_cover_pct=cloud_cover_pct,
+        )


### PR DESCRIPTION
## Summary
- implement the issue #8 scoring/domain model with monthly stub climate rows, asymmetric temperature scoring, a one-sided rain penalty, and a misery-style cloud penalty
- average monthly composite scores into an annual `0..1` result without pulling DuckDB adapter work from issues #9 and #10 into this branch
- add direct scoring tests for boundary conditions, annual aggregation, and climate-row validation, plus update the related docs/comments

Closes #8

## Testing
- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
