### PR TITLE
Add a simple local app launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ uv sync
 uv run uvicorn backend.main:app --reload
 ```
 
+## Local Testing
+
+```bash
+uv run pogodapp
+```
+
+- Starts the FastAPI app on `http://127.0.0.1:8000`
+- Uses live reload by default for local iteration
+- Still runs with stub climate rows when `data/climate.duckdb` is absent
+
+Optional flags:
+
+```bash
+uv run pogodapp --port 9000
+uv run pogodapp --no-reload
+```
+
 ## Quality Checks
 
 ```bash

--- a/backend/run_local.py
+++ b/backend/run_local.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import argparse
+
+import uvicorn
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse local launcher options."""
+    parser = argparse.ArgumentParser(description="Run Pogodapp locally.")
+    parser.add_argument("--host", default=DEFAULT_HOST, help="Host interface for the local server.")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="Port for the local server.")
+    parser.add_argument(
+        "--no-reload",
+        action="store_true",
+        help="Disable code reload while developing locally.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Launch the local app server."""
+    args = parse_args()
+    uvicorn.run("backend.main:app", host=args.host, port=args.port, reload=not args.no_reload)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
     "uvicorn[standard]>=0.42.0",
 ]
 
+[project.scripts]
+pogodapp = "backend.run_local:main"
+
 [dependency-groups]
 dev = [
     "httpx>=0.28.1",


### PR DESCRIPTION
## Summary
- add a small `uv run pogodapp` entrypoint that starts the FastAPI app without extra local-only browser behavior
- document the one-command local testing flow and supported flags in `README.md`
- keep the workflow lightweight and deployment-friendly by wrapping the existing Uvicorn app entrypoint

## Verification
- `uv run pogodapp --help`
- live startup check against `http://127.0.0.1:8765/`
- `uv run pytest`
- `uv run ruff check .`
- `uv run ty check`