### PR TITLE
Replace score circles with a grid-cell surface layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Pogodapp is a climate preference search tool, not a weather app. The user descri
 - `htmx:afterRequest` bridges the response into the map update path
 - `frontend/static/map.js` stays focused on rendering, not networking
 - The current map uses MapLibre GL with app-served static assets and a lightweight local GeoJSON world backdrop
-- The score overlay still renders as GeoJSON circles on top of that backdrop, and the textual score list remains available alongside the map
+- The score overlay now renders as a colored grid-cell surface on top of that backdrop, and the textual score list remains available alongside the map
 - DuckDB is the only runtime data store
 - The app uses `data/climate.duckdb` automatically when that file exists; otherwise it falls back to stub climate rows until the dataset lands
 
@@ -52,7 +52,7 @@ Each grid cell is scored month-by-month, then combined into one annual score.
 - `sun_preference` maps onto a cloud-cover tolerance threshold and then applies a one-sided misery-style cloud penalty
 - The stub scorer now uses one grid-cell record with 12 monthly values per climate signal and averages monthly composite scores into one annual score; DuckDB-backed data still lands in later issues
 - Final scores are normalized to the `0..1` range for map rendering
-- The current prototype renders scores as colored circle markers with larger, warmer markers indicating better matches
+- The current prototype renders scores as colored climate cells so stronger matching regions remain readable at world scale
 
 ## Repository Layout
 

--- a/frontend/static/map.js
+++ b/frontend/static/map.js
@@ -5,12 +5,16 @@ const BACKDROP_SOURCE_ID = "world-backdrop";
 const OCEAN_LAYER_ID = "world-ocean";
 const LAND_LAYER_ID = "world-land";
 const BORDER_LAYER_ID = "world-borders";
-const SCORE_SOURCE_ID = "scores";
-const SCORE_LAYER_ID = "scores-circles";
-const EMPTY_SCORE_COLLECTION = { type: "FeatureCollection", features: [] };
+const SCORE_POINT_SOURCE_ID = "score-points";
+const SCORE_SURFACE_SOURCE_ID = "score-surface";
+const SCORE_SURFACE_LAYER_ID = "score-surface";
+const CLIMATE_CELL_DEGREES = 0.5;
+const CLIMATE_CELL_HALF_DEGREES = CLIMATE_CELL_DEGREES / 2;
+const EMPTY_FEATURE_COLLECTION = { type: "FeatureCollection", features: [] };
 
 let map;
-let pendingScores = EMPTY_SCORE_COLLECTION;
+let pendingPointScores = EMPTY_FEATURE_COLLECTION;
+let pendingSurfaceScores = EMPTY_FEATURE_COLLECTION;
 
 function setMapStatus(message) {
   const status = document.getElementById("map-status");
@@ -46,9 +50,9 @@ function renderScoreList(collection) {
   }
 }
 
-function toScoreFeatureCollection(scores) {
+function toScorePointCollection(scores) {
   if (!Array.isArray(scores)) {
-    return EMPTY_SCORE_COLLECTION;
+    return EMPTY_FEATURE_COLLECTION;
   }
 
   const features = [];
@@ -78,8 +82,33 @@ function toScoreFeatureCollection(scores) {
   return { type: "FeatureCollection", features };
 }
 
+function toScoreSurfaceCollection(pointCollection) {
+  return {
+    type: "FeatureCollection",
+    features: pointCollection.features.map((feature) => {
+      const [lon, lat] = feature.geometry.coordinates;
+
+      return {
+        type: "Feature",
+        geometry: {
+          type: "Polygon",
+          coordinates: [[
+            [lon - CLIMATE_CELL_HALF_DEGREES, lat - CLIMATE_CELL_HALF_DEGREES],
+            [lon + CLIMATE_CELL_HALF_DEGREES, lat - CLIMATE_CELL_HALF_DEGREES],
+            [lon + CLIMATE_CELL_HALF_DEGREES, lat + CLIMATE_CELL_HALF_DEGREES],
+            [lon - CLIMATE_CELL_HALF_DEGREES, lat + CLIMATE_CELL_HALF_DEGREES],
+            [lon - CLIMATE_CELL_HALF_DEGREES, lat - CLIMATE_CELL_HALF_DEGREES],
+          ]],
+        },
+        properties: feature.properties,
+      };
+    }),
+  };
+}
+
 function applyScores(collection) {
-  pendingScores = collection;
+  pendingPointScores = collection;
+  pendingSurfaceScores = toScoreSurfaceCollection(collection);
   renderScoreList(collection);
 
   if (collection.features.length === 0) {
@@ -92,10 +121,15 @@ function applyScores(collection) {
     return;
   }
 
-  const source = map.getSource(SCORE_SOURCE_ID);
+  const pointSource = map.getSource(SCORE_POINT_SOURCE_ID);
+  const surfaceSource = map.getSource(SCORE_SURFACE_SOURCE_ID);
 
-  if (source) {
-    source.setData(collection);
+  if (pointSource) {
+    pointSource.setData(pendingPointScores);
+  }
+
+  if (surfaceSource) {
+    surfaceSource.setData(pendingSurfaceScores);
   }
 }
 
@@ -169,49 +203,62 @@ function initializeMap() {
       },
     });
 
-    map.addSource(SCORE_SOURCE_ID, {
+    map.addSource(SCORE_POINT_SOURCE_ID, {
       type: "geojson",
-      data: pendingScores,
+      data: pendingPointScores,
+    });
+
+    map.addSource(SCORE_SURFACE_SOURCE_ID, {
+      type: "geojson",
+      data: pendingSurfaceScores,
     });
 
     map.addLayer({
-      id: SCORE_LAYER_ID,
-      type: "circle",
-      source: SCORE_SOURCE_ID,
+      id: SCORE_SURFACE_LAYER_ID,
+      type: "fill",
+      source: SCORE_SURFACE_SOURCE_ID,
       paint: {
-        "circle-color": [
+        "fill-color": [
           "interpolate",
           ["linear"],
           ["get", "score"],
           0,
-          "#355c7d",
-          0.5,
-          "#f8b65a",
+          "rgba(53, 92, 125, 0.16)",
+          0.45,
+          "rgba(127, 179, 213, 0.35)",
+          0.65,
+          "rgba(248, 182, 90, 0.58)",
+          0.82,
+          "rgba(234, 95, 137, 0.8)",
           1,
-          "#ea5f89",
+          "rgba(121, 40, 202, 0.9)",
         ],
-        "circle-opacity": 0.82,
-        "circle-radius": [
+        "fill-opacity": [
           "interpolate",
           ["linear"],
-          ["get", "score"],
+          ["zoom"],
           0,
+          0.28,
+          1,
+          0.34,
+          2,
+          0.42,
           4,
-          1,
-          13,
+          0.56,
+          6,
+          0.74,
         ],
-        "circle-stroke-color": "#fffaf3",
-        "circle-stroke-width": 1.5,
+        "fill-outline-color": "rgba(255, 250, 243, 0.06)",
       },
     });
 
     setMapStatus("Map backdrop ready.");
-    applyScores(pendingScores);
+    applyScores(pendingPointScores);
   });
 }
 
 window.renderScores = function renderScores(scores) {
-  applyScores(toScoreFeatureCollection(scores));
+  applyScores(toScorePointCollection(scores));
 };
 
 if (document.readyState === "loading") {
@@ -220,4 +267,4 @@ if (document.readyState === "loading") {
   initializeMap();
 }
 
-renderScoreList(EMPTY_SCORE_COLLECTION);
+renderScoreList(EMPTY_FEATURE_COLLECTION);

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -48,8 +48,8 @@
         <h2>Map</h2>
         <p id="map-status" class="visually-hidden" role="status" aria-live="polite"></p>
         <p id="map-description" class="map-description">
-          Interactive world map of scored climate matches. A simple world backdrop provides context while larger,
-          warmer markers indicate higher scores.
+          Interactive world map of scored climate matches. A simple world backdrop provides context while colored
+          climate cells highlight stronger matching regions.
         </p>
         <div id="map-legend" class="map-legend" aria-label="Map legend">
           <span class="map-legend__title">Score</span>

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -92,10 +92,16 @@ def test_map_script_initializes_maplibre_score_layer() -> None:
     assert response.status_code == 200
     assert "new window.maplibregl.Map" in response.text
     assert "data: WORLD_BACKDROP_URL" in response.text
+    assert "CLIMATE_CELL_DEGREES = 0.5" in response.text
     assert "id: LAND_LAYER_ID" in response.text
     assert "id: BORDER_LAYER_ID" in response.text
-    assert "map.addSource(SCORE_SOURCE_ID" in response.text
+    assert "map.addSource(SCORE_POINT_SOURCE_ID" in response.text
+    assert "map.addSource(SCORE_SURFACE_SOURCE_ID" in response.text
     assert "map.addLayer({" in response.text
+    assert "id: SCORE_SURFACE_LAYER_ID" in response.text
+    assert 'type: "fill"' in response.text
+    assert '"fill-color"' in response.text
+    assert "toScoreSurfaceCollection" in response.text
     assert 'setMapStatus("Map backdrop ready.");' in response.text
     assert "renderScoreList(collection);" in response.text
     assert 'setMapStatus("Map library failed to load.");' in response.text


### PR DESCRIPTION
## Summary

- Replace the `circle` score overlay with a grid-cell `fill` surface that draws each scored 0.5° climate cell as a coloured polygon
- Keep the existing `/score` contract and GeoJSON point source unchanged; a second derived surface source is generated client-side from the same points
- Update map description, tests, and README to reflect the new rendering contract

## Known limitations

The current surface looks blocky at regional zoom (zoom 4+) because the underlying data is at 0.5° (~55km) resolution. This is a data problem, not a rendering problem:

- #29 — ocean/sea cells need to be filtered out with a land mask (they show as coloured sea patches and skew score normalisation)
- #30 — upgrade to 10' grid resolution; this is the real fix for blockiness and is blocked on #29

Closes #24