### PR TITLE
Cap score list to top 20 results

### DIFF
--- a/frontend/static/map.js
+++ b/frontend/static/map.js
@@ -40,7 +40,12 @@ function renderScoreList(collection) {
     return;
   }
 
-  for (const feature of collection.features) {
+  const top = collection.features
+    .slice()
+    .sort((a, b) => b.properties.score - a.properties.score)
+    .slice(0, 20);
+
+  for (const feature of top) {
     const item = document.createElement("li");
     const [lon, lat] = feature.geometry.coordinates;
     const score = feature.properties.score;

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -105,6 +105,7 @@ def test_map_script_initializes_maplibre_score_layer() -> None:
     assert 'setMapStatus("Map backdrop ready.");' in response.text
     assert "renderScoreList(collection);" in response.text
     assert 'setMapStatus("Map library failed to load.");' in response.text
+    assert ".slice(0, 20)" in response.text
 
 
 def test_map_contract_does_not_depend_on_remote_basemap_assets() -> None:


### PR DESCRIPTION
## Summary

- Sort the score feature collection descending by score before rendering the list
- Slice to top 20 entries — map surface layer still renders all cells unchanged

Stopgap before #25 (city names). Once that lands, this is superseded.

Closes #32