### PR TITLE
Polish map panel copy and control styling

### DIFF
--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -117,60 +117,45 @@ ul {
 
 .control input {
   --range-progress: 50%;
-  height: 0.9rem;
+  height: 1rem;
   width: 100%;
   margin: 0;
-  padding: 0;
-  -webkit-appearance: none;
   appearance: none;
-  background: linear-gradient(to right, #4a9eff 0 var(--range-progress), #333333 var(--range-progress) 100%) center / 100% 1px no-repeat;
-  accent-color: transparent;
-  border: 0;
-  border-radius: 0;
-  box-shadow: none;
+  background: transparent;
 }
 
 .control input::-webkit-slider-runnable-track {
   height: 1px;
-  border: 0;
-  border-radius: 0;
-  background: transparent;
-  box-shadow: none;
+  background: linear-gradient(to right, #4a9eff 0 var(--range-progress), #333333 var(--range-progress) 100%);
 }
 
 .control input::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  width: 0.35rem;
-  height: 0.85rem;
-  margin-top: -0.4rem;
+  width: 0.45rem;
+  height: 1rem;
+  margin-top: -0.475rem;
   appearance: none;
   border: 0;
   border-radius: 0;
   background: #4a9eff;
-  box-shadow: none;
 }
 
 .control input::-moz-range-track {
   height: 1px;
   border: 0;
-  border-radius: 0;
-  background: transparent;
-  box-shadow: none;
+  background: #333333;
 }
 
 .control input::-moz-range-progress {
   height: 1px;
-  border-radius: 0;
-  background: transparent;
+  background: #4a9eff;
 }
 
 .control input::-moz-range-thumb {
-  width: 0.35rem;
-  height: 0.85rem;
+  width: 0.45rem;
+  height: 1rem;
   border: 0;
   border-radius: 0;
   background: #4a9eff;
-  box-shadow: none;
 }
 
 .control input:focus-visible {
@@ -186,37 +171,38 @@ ul {
 }
 
 .map-panel {
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: auto auto auto minmax(0, 1fr);
   min-height: 0;
+}
+
+.map-description {
+  color: #666666;
+  line-height: 1.5;
 }
 
 .map-legend {
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   gap: 1rem;
   align-items: center;
   color: #666666;
-  font-size: 0.9rem;
-  white-space: nowrap;
 }
 
 .map-legend__item {
-  display: inline;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
 }
 
-.map-legend__swatch {
-  margin-right: 0.25rem;
-}
-
-.map-legend__swatch--low {
+.map-legend__item--low span {
   color: #355c7d;
 }
 
-.map-legend__swatch--mid {
+.map-legend__item--mid span {
   color: #f8b65a;
 }
 
-.map-legend__swatch--high {
+.map-legend__item--high span {
   color: #ea5f89;
 }
 
@@ -227,7 +213,7 @@ ul {
 
 #score-results-list {
   display: grid;
-  gap: 0.1rem;
+  gap: 0.35rem;
   padding: 0;
   list-style: none;
   overflow: auto;
@@ -239,7 +225,6 @@ ul {
   grid-template-columns: 5ch minmax(0, 1fr) auto;
   gap: 1rem;
   align-items: baseline;
-  line-height: 1.15;
 }
 
 .score-results__score {

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -46,12 +46,16 @@
       </section>
 
       <section class="app-panel map-panel" aria-label="Map container">
+        <h2>Map</h2>
         <p id="map-status" class="visually-hidden" role="status" aria-live="polite"></p>
-        <p id="map-description" class="visually-hidden">Interactive climate score map.</p>
+        <p id="map-description" class="map-description">
+          Interactive world map of scored climate matches. Dark land and ocean layers keep the heatmap readable while
+          borders stay visible.
+        </p>
         <div id="map-legend" class="map-legend" aria-label="Map legend">
-          <span class="map-legend__item"><span class="map-legend__swatch map-legend__swatch--low" aria-hidden="true">■</span> LOW</span>
-          <span class="map-legend__item"><span class="map-legend__swatch map-legend__swatch--mid" aria-hidden="true">■</span> MED</span>
-          <span class="map-legend__item"><span class="map-legend__swatch map-legend__swatch--high" aria-hidden="true">■</span> HIGH</span>
+          <span class="map-legend__item map-legend__item--low"><span aria-hidden="true">■</span> LOW</span>
+          <span class="map-legend__item map-legend__item--mid"><span aria-hidden="true">■</span> MED</span>
+          <span class="map-legend__item map-legend__item--high"><span aria-hidden="true">■</span> HIGH</span>
         </div>
         <div id="map" role="region" aria-label="Interactive climate score map" aria-describedby="map-description map-legend map-status"></div>
       </section>

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -20,7 +20,8 @@ def test_home_page_renders() -> None:
     assert 'id="map-description"' in response.text
     assert 'id="map-status"' in response.text
     assert 'id="map-legend"' in response.text
-    assert "Interactive climate score map." in response.text
+    assert "Interactive world map of scored climate matches." in response.text
+    assert ">Map</h2>" in response.text
     assert (
         'id="map" role="region" aria-label="Interactive climate score map" aria-describedby="map-description map-legend map-status"'
         in response.text


### PR DESCRIPTION
## Summary
- polish the map panel presentation with a visible section heading, explanatory copy, and cleaner legend markup
- refine slider track/thumb styling and spacing so controls read more cleanly in the dark shell
- loosen the app shell test to assert the updated map copy instead of the old visually-hidden text

## Validation
- uv run ruff check .
- uv run ty check
- uv run pytest