### PR TITLE
Reduce runtime RAM in climate cache

### DIFF
--- a/backend/climate_repository.py
+++ b/backend/climate_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING, Protocol, cast, overload
 
 import duckdb
 import numpy as np
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
 MONTH_NAMES = ("jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec")
+FLOAT32_DTYPE = np.dtype(np.float32)
+UINT8_DTYPE = np.dtype(np.uint8)
 
 SELECT_CLIMATE_CELLS_QUERY = """
 SELECT
@@ -181,12 +183,12 @@ class DuckDbClimateRepository:
 
         try:
             columns = self._fetch_numpy_columns(SELECT_CLIMATE_MATRIX_QUERY)
-            latitudes = np.asarray(columns["lat"], dtype=np.float32)
-            longitudes = np.asarray(columns["lon"], dtype=np.float32)
-            temperature_min_c = self._build_monthly_matrix(columns, TEMPERATURE_MIN_COLUMNS, dtype=np.float32)
-            temperature_max_c = self._build_monthly_matrix(columns, TEMPERATURE_MAX_COLUMNS, dtype=np.float32)
-            precipitation_mm = self._build_monthly_matrix(columns, PRECIPITATION_COLUMNS, dtype=np.float32)
-            cloud_cover_pct = self._build_monthly_matrix(columns, CLOUD_COLUMNS, dtype=np.uint8)
+            latitudes = np.asarray(columns["lat"], dtype=FLOAT32_DTYPE)
+            longitudes = np.asarray(columns["lon"], dtype=FLOAT32_DTYPE)
+            temperature_min_c = self._build_monthly_matrix(columns, TEMPERATURE_MIN_COLUMNS, dtype=FLOAT32_DTYPE)
+            temperature_max_c = self._build_monthly_matrix(columns, TEMPERATURE_MAX_COLUMNS, dtype=FLOAT32_DTYPE)
+            precipitation_mm = self._build_monthly_matrix(columns, PRECIPITATION_COLUMNS, dtype=FLOAT32_DTYPE)
+            cloud_cover_pct = self._build_monthly_matrix(columns, CLOUD_COLUMNS, dtype=UINT8_DTYPE)
         except (KeyError, TypeError, ValueError) as error:
             msg = f"Failed to map climate data from {self.database_path} into climate rows: {error}"
             raise ClimateDataError(msg) from error
@@ -281,6 +283,24 @@ class DuckDbClimateRepository:
             msg = f"Failed to read climate data from {self.database_path}: {error}"
             raise ClimateDataError(msg) from error
 
+    @overload
+    def _build_monthly_matrix(
+        self,
+        columns: dict[str, NDArray[np.generic]],
+        month_columns: tuple[str, ...],
+        *,
+        dtype: np.dtype[np.float32],
+    ) -> NDArray[np.float32]: ...
+
+    @overload
+    def _build_monthly_matrix(
+        self,
+        columns: dict[str, NDArray[np.generic]],
+        month_columns: tuple[str, ...],
+        *,
+        dtype: np.dtype[np.uint8],
+    ) -> NDArray[np.uint8]: ...
+
     def _build_monthly_matrix(
         self,
         columns: dict[str, NDArray[np.generic]],
@@ -292,7 +312,7 @@ class DuckDbClimateRepository:
         matrix = np.empty((row_count, MONTHS_PER_YEAR), dtype=dtype)
         for month_index, column_name in enumerate(month_columns):
             matrix[:, month_index] = np.asarray(columns[column_name], dtype=dtype)
-        return matrix
+        return cast("NDArray[np.float32] | NDArray[np.uint8]", matrix)
 
     def _row_to_climate_cell(self, row: tuple[object, ...]) -> ClimateCell:
         """Convert one database row into the in-memory scoring shape."""

--- a/backend/climate_repository.py
+++ b/backend/climate_repository.py
@@ -18,6 +18,10 @@ from backend.scoring import MONTHS_PER_YEAR, STUB_CLIMATE_CELLS, ClimateCell, Cl
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from numpy.typing import NDArray
+
+MONTH_NAMES = ("jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec")
+
 SELECT_CLIMATE_CELLS_QUERY = """
 SELECT
     lat,
@@ -29,6 +33,26 @@ SELECT
     cloud_jan, cloud_feb, cloud_mar, cloud_apr, cloud_may, cloud_jun, cloud_jul, cloud_aug, cloud_sep, cloud_oct, cloud_nov, cloud_dec
 FROM climate_cells
 """
+
+TEMPERATURE_COLUMNS = tuple(f"t_{month}" for month in MONTH_NAMES)
+TEMPERATURE_MIN_COLUMNS = tuple(f"tmin_{month}" for month in MONTH_NAMES)
+TEMPERATURE_MAX_COLUMNS = tuple(f"tmax_{month}" for month in MONTH_NAMES)
+PRECIPITATION_COLUMNS = tuple(f"prec_{month}" for month in MONTH_NAMES)
+CLOUD_COLUMNS = tuple(f"cloud_{month}" for month in MONTH_NAMES)
+SELECT_CLIMATE_MATRIX_QUERY = (
+    "SELECT\n    "
+    + ",\n    ".join(
+        (
+            "lat",
+            "lon",
+            *TEMPERATURE_MIN_COLUMNS,
+            *TEMPERATURE_MAX_COLUMNS,
+            *PRECIPITATION_COLUMNS,
+            *CLOUD_COLUMNS,
+        )
+    )
+    + "\nFROM climate_cells"
+)
 
 CITY_BASE_COLUMNS = ("name", "country_code", "lat", "lon", "cell_lat", "cell_lon")
 
@@ -47,7 +71,12 @@ class ClimateRepository(Protocol):
         """Return user-facing cities already mapped onto the dataset."""
 
     def get_climate_matrix(self) -> ClimateMatrix:
-        """Return compact climate arrays ready for vectorized scoring."""
+        """Return compact climate arrays ready for vectorized scoring.
+
+        DuckDB-backed repositories may omit `temperature_c` and return `None`
+        there; callers should rely on the min/max, precipitation, and cloud
+        arrays for hot-path work.
+        """
 
     def get_indexed_cities(self) -> CityRankingCache:
         """Return ranking-ready cities aligned with the current climate-matrix row order."""
@@ -138,51 +167,34 @@ class DuckDbClimateRepository:
         return self._cities
 
     def get_climate_matrix(self) -> ClimateMatrix:
-        """Load the climate table once into compact arrays for repeated scoring."""
+        """Load the scoring columns once into compact arrays for repeated scoring.
+
+        Monthly mean temperatures are omitted from the cached runtime matrix to
+        reduce RAM.
+
+        Raises:
+            ClimateDataError: The database file is missing, unreadable, or does
+                not match the runtime matrix contract.
+        """
         if self._climate_matrix is not None:
             return self._climate_matrix
 
-        rows = self._fetch_rows(SELECT_CLIMATE_CELLS_QUERY)
-        row_count = len(rows)
-        latitudes = np.empty(row_count, dtype=np.float32)
-        longitudes = np.empty(row_count, dtype=np.float32)
-        temperature_c = np.empty((row_count, MONTHS_PER_YEAR), dtype=np.float32)
-        temperature_min_c = np.empty((row_count, MONTHS_PER_YEAR), dtype=np.float32)
-        temperature_max_c = np.empty((row_count, MONTHS_PER_YEAR), dtype=np.float32)
-        precipitation_mm = np.empty((row_count, MONTHS_PER_YEAR), dtype=np.float32)
-        cloud_cover_pct = np.empty((row_count, MONTHS_PER_YEAR), dtype=np.uint8)
-
         try:
-            for index, row in enumerate(rows):
-                latitude, longitude, *monthly_values = row
-                latitudes[index] = float(cast("int | float", latitude))
-                longitudes[index] = float(cast("int | float", longitude))
-                temperature_c[index] = tuple(
-                    float(cast("int | float", value)) for value in monthly_values[:MONTHS_PER_YEAR]
-                )
-                temperature_min_c[index] = tuple(
-                    float(cast("int | float", value)) for value in monthly_values[MONTHS_PER_YEAR : MONTHS_PER_YEAR * 2]
-                )
-                temperature_max_c[index] = tuple(
-                    float(cast("int | float", value))
-                    for value in monthly_values[MONTHS_PER_YEAR * 2 : MONTHS_PER_YEAR * 3]
-                )
-                precipitation_mm[index] = tuple(
-                    float(cast("int | float", value))
-                    for value in monthly_values[MONTHS_PER_YEAR * 3 : MONTHS_PER_YEAR * 4]
-                )
-                cloud_cover_pct[index] = tuple(
-                    int(cast("int | float", value))
-                    for value in monthly_values[MONTHS_PER_YEAR * 4 : MONTHS_PER_YEAR * 5]
-                )
-        except (TypeError, ValueError) as error:
+            columns = self._fetch_numpy_columns(SELECT_CLIMATE_MATRIX_QUERY)
+            latitudes = np.asarray(columns["lat"], dtype=np.float32)
+            longitudes = np.asarray(columns["lon"], dtype=np.float32)
+            temperature_min_c = self._build_monthly_matrix(columns, TEMPERATURE_MIN_COLUMNS, dtype=np.float32)
+            temperature_max_c = self._build_monthly_matrix(columns, TEMPERATURE_MAX_COLUMNS, dtype=np.float32)
+            precipitation_mm = self._build_monthly_matrix(columns, PRECIPITATION_COLUMNS, dtype=np.float32)
+            cloud_cover_pct = self._build_monthly_matrix(columns, CLOUD_COLUMNS, dtype=np.uint8)
+        except (KeyError, TypeError, ValueError) as error:
             msg = f"Failed to map climate data from {self.database_path} into climate rows: {error}"
             raise ClimateDataError(msg) from error
 
         self._climate_matrix = ClimateMatrix(
             latitudes=latitudes,
             longitudes=longitudes,
-            temperature_c=temperature_c,
+            temperature_c=None,
             temperature_min_c=temperature_min_c,
             temperature_max_c=temperature_max_c,
             precipitation_mm=precipitation_mm,
@@ -256,6 +268,31 @@ class DuckDbClimateRepository:
                 raise ClimateDataError(msg) from error
             msg = f"Failed to read climate data from {self.database_path}: {error}"
             raise ClimateDataError(msg) from error
+
+    def _fetch_numpy_columns(self, query: str) -> dict[str, NDArray[np.generic]]:
+        if not self.database_path.exists():
+            msg = f"Climate database file not found: {self.database_path}"
+            raise ClimateDataError(msg)
+
+        try:
+            with duckdb.connect(str(self.database_path), read_only=True) as connection:
+                return cast("dict[str, NDArray[np.generic]]", connection.execute(query).fetchnumpy())
+        except duckdb.Error as error:
+            msg = f"Failed to read climate data from {self.database_path}: {error}"
+            raise ClimateDataError(msg) from error
+
+    def _build_monthly_matrix(
+        self,
+        columns: dict[str, NDArray[np.generic]],
+        month_columns: tuple[str, ...],
+        *,
+        dtype: np.dtype[np.float32] | np.dtype[np.uint8],
+    ) -> NDArray[np.float32] | NDArray[np.uint8]:
+        row_count = len(columns[month_columns[0]])
+        matrix = np.empty((row_count, MONTHS_PER_YEAR), dtype=dtype)
+        for month_index, column_name in enumerate(month_columns):
+            matrix[:, month_index] = np.asarray(columns[column_name], dtype=dtype)
+        return matrix
 
     def _row_to_climate_cell(self, row: tuple[object, ...]) -> ClimateCell:
         """Convert one database row into the in-memory scoring shape."""

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -91,11 +91,11 @@ class ClimateCell:
 
 @dataclass(frozen=True, slots=True)
 class ClimateMatrix:
-    """Compact climate features for vectorized scoring."""
+    """Compact climate features for vectorized scoring; monthly averages may be omitted."""
 
     latitudes: NDArray[np.float32]
     longitudes: NDArray[np.float32]
-    temperature_c: NDArray[np.float32]
+    temperature_c: NDArray[np.float32] | None
     temperature_min_c: NDArray[np.float32]
     temperature_max_c: NDArray[np.float32]
     precipitation_mm: NDArray[np.float32]
@@ -109,7 +109,7 @@ class ClimateMatrix:
             msg = "longitudes must align with latitudes"
             raise ValueError(msg)
 
-        if self.temperature_c.shape != (cell_count, MONTHS_PER_YEAR):
+        if self.temperature_c is not None and self.temperature_c.shape != (cell_count, MONTHS_PER_YEAR):
             msg = "temperature_c must be shaped (cells, 12)"
             raise ValueError(msg)
 
@@ -462,17 +462,7 @@ def score_matrix_row_breakdown(
     row_index: int,
     preferences: PreferenceInputs,
 ) -> ProbeBreakdown:
-    """Build `/probe` metrics from typical high plus yearly high/low extremes for one cell."""
-    row_cell = ClimateCell(
-        lat=float(climate_matrix.latitudes[row_index]),
-        lon=float(climate_matrix.longitudes[row_index]),
-        temperature_c=tuple(float(value) for value in climate_matrix.temperature_c[row_index]),
-        temperature_min_c=tuple(float(value) for value in climate_matrix.temperature_min_c[row_index]),
-        temperature_max_c=tuple(float(value) for value in climate_matrix.temperature_max_c[row_index]),
-        precipitation_mm=tuple(float(value) for value in climate_matrix.precipitation_mm[row_index]),
-        cloud_cover_pct=tuple(int(value) for value in climate_matrix.cloud_cover_pct[row_index]),
-    )
-
+    """Build `/probe` metrics from min/max, rain, and cloud rows without cached mean temperatures."""
     typical_high_value = float(np.median(climate_matrix.temperature_max_c[row_index]))
     hottest_month_high_value = float(np.max(climate_matrix.temperature_max_c[row_index]))
     coldest_month_low_value = float(np.min(climate_matrix.temperature_min_c[row_index]))
@@ -488,9 +478,30 @@ def score_matrix_row_breakdown(
     avg_precip_mm = round(float(np.mean(climate_matrix.precipitation_mm[row_index])), 1)
     avg_cloud_pct = round(float(np.mean(climate_matrix.cloud_cover_pct[row_index].astype(np.float32))), 1)
     avg_sun_pct = round(100.0 - avg_cloud_pct, 1)
-    rain_score_value = round(rain_profile_score(row_cell.precipitation_mm, preferences.dryness_preference), 3)
-    sun_score_value = round(sunshine_profile_score(row_cell.cloud_cover_pct, preferences.sunshine_preference), 3)
-    overall_score = round(annual_score(row_cell, preferences), 4)
+    monthly_precipitation = tuple(float(value) for value in climate_matrix.precipitation_mm[row_index])
+    monthly_cloud_cover = tuple(int(value) for value in climate_matrix.cloud_cover_pct[row_index])
+    temperature_score_value = weighted_product_score(
+        (typical_score, TEMPERATURE_IDEAL_WEIGHT),
+        (high_score, TEMPERATURE_HEAT_WEIGHT),
+        (low_score, TEMPERATURE_COLD_WEIGHT),
+    )
+    rain_score = rain_profile_score(monthly_precipitation, preferences.dryness_preference)
+    sun_score = sunshine_profile_score(monthly_cloud_cover, preferences.sunshine_preference)
+    temperature_weight, rain_weight, sun_weight = preference_block_weights(
+        preferences.dryness_preference,
+        preferences.sunshine_preference,
+    )
+    preference_score_value = weighted_product_score(
+        (rain_score, rain_weight),
+        (sun_score, sun_weight),
+    )
+    overall_score = round(
+        weighted_product_score(
+            (temperature_score_value, temperature_weight),
+            (preference_score_value, 1 - temperature_weight),
+        ),
+        4,
+    )
     metric_scores = (
         ProbeMetricBreakdown(
             key="temp",
@@ -518,14 +529,14 @@ def score_matrix_row_breakdown(
             label="rain",
             value=avg_precip_mm,
             display_value=f"{round(avg_precip_mm)}mm/mo",
-            score=rain_score_value,
+            score=round(rain_score, 3),
         ),
         ProbeMetricBreakdown(
             key="sun",
             label="sun",
             value=avg_sun_pct,
             display_value=f"{round(avg_sun_pct)}% sun",
-            score=sun_score_value,
+            score=round(sun_score, 3),
         ),
     )
     return ProbeBreakdown(overall_score=overall_score, metrics=metric_scores)

--- a/tests/test_climate_repository.py
+++ b/tests/test_climate_repository.py
@@ -99,6 +99,56 @@ def test_duckdb_climate_repository_loads_monthly_climate_rows(tmp_path: Path) ->
     )
 
 
+def test_duckdb_climate_repository_loads_compact_matrix_with_expected_order_and_dtypes(tmp_path: Path) -> None:
+    database_path = tmp_path / "climate.duckdb"
+    with duckdb.connect(str(database_path)) as connection:
+        connection.execute(
+            """
+            CREATE TABLE climate_cells AS
+            SELECT
+                10.5 AS lat,
+                20.5 AS lon,
+                1.0 AS t_jan, 2.0 AS t_feb, 3.0 AS t_mar, 4.0 AS t_apr, 5.0 AS t_may, 6.0 AS t_jun,
+                7.0 AS t_jul, 8.0 AS t_aug, 9.0 AS t_sep, 10.0 AS t_oct, 11.0 AS t_nov, 12.0 AS t_dec,
+                -1.0 AS tmin_jan, 0.0 AS tmin_feb, 1.0 AS tmin_mar, 2.0 AS tmin_apr, 3.0 AS tmin_may, 4.0 AS tmin_jun,
+                5.0 AS tmin_jul, 6.0 AS tmin_aug, 7.0 AS tmin_sep, 8.0 AS tmin_oct, 9.0 AS tmin_nov, 10.0 AS tmin_dec,
+                3.0 AS tmax_jan, 4.0 AS tmax_feb, 5.0 AS tmax_mar, 6.0 AS tmax_apr, 7.0 AS tmax_may, 8.0 AS tmax_jun,
+                9.0 AS tmax_jul, 10.0 AS tmax_aug, 11.0 AS tmax_sep, 12.0 AS tmax_oct, 13.0 AS tmax_nov, 14.0 AS tmax_dec,
+                13.0 AS prec_jan, 14.0 AS prec_feb, 15.0 AS prec_mar, 16.0 AS prec_apr, 17.0 AS prec_may, 18.0 AS prec_jun,
+                19.0 AS prec_jul, 20.0 AS prec_aug, 21.0 AS prec_sep, 22.0 AS prec_oct, 23.0 AS prec_nov, 24.0 AS prec_dec,
+                25 AS cloud_jan, 26 AS cloud_feb, 27 AS cloud_mar, 28 AS cloud_apr, 29 AS cloud_may, 30 AS cloud_jun,
+                31 AS cloud_jul, 32 AS cloud_aug, 33 AS cloud_sep, 34 AS cloud_oct, 35 AS cloud_nov, 36 AS cloud_dec
+            """
+        )
+
+    matrix = DuckDbClimateRepository(database_path).get_climate_matrix()
+
+    assert matrix.temperature_c is None
+    assert matrix.latitudes.dtype == np.float32
+    assert matrix.longitudes.dtype == np.float32
+    assert matrix.temperature_min_c.dtype == np.float32
+    assert matrix.temperature_max_c.dtype == np.float32
+    assert matrix.precipitation_mm.dtype == np.float32
+    assert matrix.cloud_cover_pct.dtype == np.uint8
+    assert matrix.temperature_min_c.tolist() == [[-1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]]
+    assert matrix.temperature_max_c.tolist() == [[3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0]]
+    assert matrix.precipitation_mm.tolist() == [
+        [13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0]
+    ]
+    assert matrix.cloud_cover_pct.tolist() == [[25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36]]
+
+
+def test_duckdb_climate_repository_raises_clear_error_for_compact_matrix_schema_mismatch(tmp_path: Path) -> None:
+    database_path = tmp_path / "climate.duckdb"
+    with duckdb.connect(str(database_path)) as connection:
+        connection.execute(
+            "CREATE TABLE climate_cells (lat DOUBLE, lon DOUBLE, tmin_jan DOUBLE, tmax_jan DOUBLE, prec_jan DOUBLE)"
+        )
+
+    with pytest.raises(ClimateDataError, match="Failed to read climate data"):
+        DuckDbClimateRepository(database_path).get_climate_matrix()
+
+
 def test_duckdb_climate_repository_loads_city_rows(tmp_path: Path) -> None:
     database_path = tmp_path / "climate.duckdb"
     with duckdb.connect(str(database_path)) as connection:
@@ -315,7 +365,7 @@ def test_create_app_preloads_optimized_repository() -> None:
             return ClimateMatrix(
                 latitudes=np.array([], dtype=np.float32),
                 longitudes=np.array([], dtype=np.float32),
-                temperature_c=np.empty((0, 12), dtype=np.float32),
+                temperature_c=None,
                 temperature_min_c=np.empty((0, 12), dtype=np.float32),
                 temperature_max_c=np.empty((0, 12), dtype=np.float32),
                 precipitation_mm=np.empty((0, 12), dtype=np.float32),
@@ -618,6 +668,7 @@ def test_duckdb_city_cache_aligns_indexes_with_shuffled_climate_rows(tmp_path: P
     climate_matrix = repository.get_climate_matrix()
     city_cache = repository.get_indexed_cities()
 
+    assert climate_matrix.temperature_c is None
     assert [city.name for city in city_cache.cities] == ["First Match"]
     mapped_index = int(city_cache.climate_indexes[0])
     assert float(climate_matrix.latitudes[mapped_index]) == 1.0

--- a/tests/test_score_service.py
+++ b/tests/test_score_service.py
@@ -73,7 +73,7 @@ def test_build_score_response_returns_empty_payload_for_empty_matrix() -> None:
             return ClimateMatrix(
                 latitudes=np.array([], dtype=np.float32),
                 longitudes=np.array([], dtype=np.float32),
-                temperature_c=np.empty((0, 12), dtype=np.float32),
+                temperature_c=None,
                 temperature_min_c=np.empty((0, 12), dtype=np.float32),
                 temperature_max_c=np.empty((0, 12), dtype=np.float32),
                 precipitation_mm=np.empty((0, 12), dtype=np.float32),

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -229,7 +229,7 @@ def test_vectorized_scoring_matches_scalar_scoring_for_stub_cells() -> None:
     climate_matrix = ClimateMatrix(
         latitudes=np.array([cell.lat for cell in STUB_CLIMATE_CELLS], dtype=np.float32),
         longitudes=np.array([cell.lon for cell in STUB_CLIMATE_CELLS], dtype=np.float32),
-        temperature_c=np.array([cell.temperature_c for cell in STUB_CLIMATE_CELLS], dtype=np.float32),
+        temperature_c=None,
         temperature_min_c=np.array([cell.temperature_min_c for cell in STUB_CLIMATE_CELLS], dtype=np.float32),
         temperature_max_c=np.array([cell.temperature_max_c for cell in STUB_CLIMATE_CELLS], dtype=np.float32),
         precipitation_mm=np.array([cell.precipitation_mm for cell in STUB_CLIMATE_CELLS], dtype=np.float32),
@@ -294,3 +294,21 @@ def test_score_matrix_row_breakdown_returns_structured_probe_metrics() -> None:
     assert [metric.key for metric in breakdown.metrics] == ["temp", "high", "low", "rain", "sun"]
     assert [metric.label for metric in breakdown.metrics] == ["temp", "high", "low", "rain", "sun"]
     assert all(metric.display_value for metric in breakdown.metrics)
+
+
+def test_score_matrix_row_breakdown_works_without_cached_average_temperatures() -> None:
+    source = STUB_CLIMATE_CELLS[0]
+    climate_matrix = ClimateMatrix(
+        latitudes=np.array([source.lat], dtype=np.float32),
+        longitudes=np.array([source.lon], dtype=np.float32),
+        temperature_c=None,
+        temperature_min_c=np.array([source.temperature_min_c], dtype=np.float32),
+        temperature_max_c=np.array([source.temperature_max_c], dtype=np.float32),
+        precipitation_mm=np.array([source.precipitation_mm], dtype=np.float32),
+        cloud_cover_pct=np.array([source.cloud_cover_pct], dtype=np.uint8),
+    )
+
+    breakdown = score_matrix_row_breakdown(climate_matrix, 0, make_preferences())
+
+    assert isinstance(breakdown, ProbeBreakdown)
+    assert 0 <= breakdown.overall_score <= 1


### PR DESCRIPTION
## Summary
- replace the hot climate-matrix `fetchall()` load with DuckDB `fetchnumpy()` column reads to avoid the large startup Python-object spike
- stop caching monthly mean `t_*` arrays in the runtime matrix while preserving the 5m dataset and request contract
- keep `/probe` aligned with the lean matrix path and add regression coverage for compact matrix ordering, dtypes, and schema failures

## Testing
- `uv run ruff check backend tests`
- `uv run pytest`