### PR TITLE
Reduce /score latency and structure app logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Railway-specific notes from the platform docs:
 
 ## Observability
 
-- Pogodapp emits its own request logs instead of Uvicorn access logs.
-- Request logs include `outcome`, `method`, `path`, `query`, `status`, `client`, `scheme`, `http_version`, `bytes`, and `duration_ms`.
+- Pogodapp emits its own request logs instead of Uvicorn access logs, including on Railway.
+- Request logs are structured around `event=http_request` and include `outcome`, `method`, `path`, `query`, `httpStatus`, `srcIp`, `scheme`, `httpVersion`, `txBytes`, `responseTime`, and `host`.
 - Local runs use plain stdout logs; Railway uses single-line JSON on stdout for ingestion.
 
 ## Build Climate Data

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It is not a weather app. It scores long-term climate normals against a few user 
 ## How It Works
 
 - `GET /` renders the page.
+- `GET /` renders the shell only; the first results arrive through an automatic HTMX `load` `POST /score` using the backend default preferences.
 - `POST /score` accepts `preferred_day_temperature`, `summer_heat_limit`, `winter_cold_limit`, `dryness_preference`, and `sunshine_preference` as form fields and returns JSON.
 - The response shape is `{"scores": [{"name", "continent", "country_code", "flag", "score", "lat", "lon", "probe_lat", "probe_lon"}, ...], "heatmap": "data:image/png;base64,..."}`.
 - Empty or all-zero results return `{"scores": [], "heatmap": ""}`.
@@ -88,6 +89,7 @@ Notes:
 - Default local URL: `http://127.0.0.1:8000`
 - Live reload is on by default.
 - If `data/climate.duckdb` exists, startup warms the climate matrix, city cache, and heatmap projection.
+- When climate data is available, startup also precomputes and caches the default `/score` response; if that warmup hits a climate-data failure, startup logs it and continues.
 - If preload fails, startup logs the problem and requests fall back to the existing `503` path.
 - Large dynamic responses are gzip-compressed when the client sends `Accept-Encoding: gzip`; small responses like `/health` may stay uncompressed.
 
@@ -137,6 +139,8 @@ Railway-specific notes from the platform docs:
 
 - Pogodapp emits its own request logs instead of Uvicorn access logs, including on Railway.
 - Request logs are structured around `event=http_request` and include `outcome`, `method`, `path`, `query`, `httpStatus`, `srcIp`, `scheme`, `httpVersion`, `txBytes`, `responseTime`, and `host`.
+- Other structured events include `startup`, `startup_db`, `startup_bootstrap`, `startup_preload`, `startup_default_score`, `score_request`, and `probe_request`.
+- Railway JSON logs always include `level`, `message`, `timestamp`, `logger`, and any event-specific fields attached to the record.
 - Local runs use plain stdout logs; Railway uses single-line JSON on stdout for ingestion.
 
 ## Build Climate Data

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ It is not a weather app. It scores long-term climate normals against a few user 
 - `POST /score` accepts `preferred_day_temperature`, `summer_heat_limit`, `winter_cold_limit`, `dryness_preference`, and `sunshine_preference` as form fields and returns JSON.
 - The response shape is `{"scores": [{"name", "continent", "country_code", "flag", "score", "lat", "lon", "probe_lat", "probe_lon"}, ...], "heatmap": "data:image/png;base64,..."}`.
 - Empty or all-zero results return `{"scores": [], "heatmap": ""}`.
+- `/score` is rate-limited to `30/minute` per client and returns `429` when that limit is exceeded.
 - `GET /probe` accepts the same preference fields plus `lat` and `lon`, then returns `{"found": bool, "overall_score": 0..1, "metrics": [{"key", "label", "value", "display_value", "score"}, ...]}`.
+- `/probe` is rate-limited to `120/minute` per client and returns `429` when that limit is exceeded.
 - Both `/score` and `/probe` return `422` when `preferred_day_temperature` falls above `summer_heat_limit` or below `winter_cold_limit`.
 - `/probe` metric keys are `temp`, `high`, `low`, `rain`, and `sun`.
 - `/probe` temperature metrics mean: `temp` = typical day from median monthly high, `high` = hottest-month high, `low` = coldest-month low.
@@ -37,6 +39,7 @@ It is not a weather app. It scores long-term climate normals against a few user 
 - FastAPI handles HTTP and validation.
 - Scoring, ranking, and heatmap rendering stay out of the route layer.
 - `frontend/static/map.js` only renders. HTMX submits the form and hands the response to the map code.
+- Tooltip probes snap hover points to the climate grid, cache results by snapped cell plus current preferences, wait `80ms` before hover lookup, then add a `250ms` cooldown for uncached free-map probes while canceling stale work on mouseleave and preference edits.
 
 ## Data
 
@@ -90,6 +93,7 @@ Notes:
 - Live reload is on by default.
 - If `data/climate.duckdb` exists, startup warms the climate matrix, city cache, and heatmap projection.
 - When climate data is available, startup also precomputes and caches the default `/score` response; if that warmup hits a climate-data failure, startup logs it and continues.
+- The `/score` cache is per-worker, in-memory, bounded to `16` entries today, and collapses identical concurrent requests only within the same process.
 - If preload fails, startup logs the problem and requests fall back to the existing `503` path.
 - Large dynamic responses are gzip-compressed when the client sends `Accept-Encoding: gzip`; small responses like `/health` may stay uncompressed.
 
@@ -140,6 +144,7 @@ Railway-specific notes from the platform docs:
 - Pogodapp emits its own request logs instead of Uvicorn access logs, including on Railway.
 - Request logs are structured around `event=http_request` and include `outcome`, `method`, `path`, `query`, `httpStatus`, `srcIp`, `scheme`, `httpVersion`, `txBytes`, `responseTime`, and `host`.
 - Other structured events include `startup`, `startup_db`, `startup_bootstrap`, `startup_preload`, `startup_default_score`, `score_request`, and `probe_request`.
+- `score_request` logs also include `total_ms`, `cells_ms`, `cities_ms`, `scoring_ms`, `normalize_ms`, `ranking_ms`, `heatmap_ms`, `climate_cells`, `cities`, and `ranked_cities`.
 - Railway JSON logs always include `level`, `message`, `timestamp`, `logger`, and any event-specific fields attached to the record.
 - Local runs use plain stdout logs; Railway uses single-line JSON on stdout for ingestion.
 

--- a/backend/heatmap.py
+++ b/backend/heatmap.py
@@ -166,7 +166,9 @@ def render_heatmap_png_from_projection(projection: HeatmapProjection, scores: np
     blurred_gray = np.asarray(pil_gray, dtype=np.uint8) * projection.land_mask
     styled_gray = _stylize_heatmap_gray(_preserve_local_maxima(base_gray, blurred_gray))
     peak_floor = np.where(base_gray >= PEAK_BOOST_THRESHOLD * 255.0, styled_gray, 0)
-    styled_gray = (np.maximum(_smooth_styled_heatmap_gray(styled_gray), peak_floor) * projection.land_mask).astype(np.uint8)
+    styled_gray = (np.maximum(_smooth_styled_heatmap_gray(styled_gray), peak_floor) * projection.land_mask).astype(
+        np.uint8
+    )
     rgba = _COLOR_RAMP_LOOKUP[styled_gray]
 
     buf = BytesIO()

--- a/backend/heatmap.py
+++ b/backend/heatmap.py
@@ -53,6 +53,8 @@ class HeatmapProjection:
     score_indexes: NDArray[np.int32]
     xs: NDArray[np.int32]
     ys: NDArray[np.int32]
+    # Pre-dilated land mask: MaxFilter(7) is grid-fixed, not score-dependent.
+    land_mask: NDArray[np.bool_]
 
     @classmethod
     def from_coordinates(cls, latitudes: np.ndarray, longitudes: np.ndarray) -> HeatmapProjection:
@@ -67,10 +69,18 @@ class HeatmapProjection:
         ys = ((_Y_MAX - y_merc) / (2 * _Y_MAX) * HEIGHT).astype(np.int32)
 
         in_bounds = (xs >= 0) & (xs < WIDTH) & (ys >= 0) & (ys < HEIGHT)
+        final_xs = xs[in_bounds]
+        final_ys = ys[in_bounds]
+
+        land_mask_raw = np.zeros((HEIGHT, WIDTH), dtype=np.uint8)
+        land_mask_raw[final_ys, final_xs] = 255
+        land_mask = np.asarray(Image.fromarray(land_mask_raw, mode="L").filter(ImageFilter.MaxFilter(7))) > 0
+
         return cls(
             score_indexes=valid_indexes[in_bounds],
-            xs=xs[in_bounds],
-            ys=ys[in_bounds],
+            xs=final_xs,
+            ys=final_ys,
+            land_mask=land_mask,
         )
 
 
@@ -150,18 +160,13 @@ def render_heatmap_png_from_projection(projection: HeatmapProjection, scores: np
     grid = np.zeros((HEIGHT, WIDTH), dtype=np.float32)
     np.maximum.at(grid, (projection.ys, projection.xs), scores[projection.score_indexes])
 
-    # Dilate the land mask so sparse high-latitude scanlines do not stripe after blur.
-    land_mask_raw = np.zeros((HEIGHT, WIDTH), dtype=np.uint8)
-    land_mask_raw[projection.ys, projection.xs] = 255
-    land_mask = np.asarray(Image.fromarray(land_mask_raw, mode="L").filter(ImageFilter.MaxFilter(7))) > 0
-
     base_gray = (grid * 255).astype(np.uint8)
     pil_gray = Image.fromarray(base_gray, mode="L")
     pil_gray = pil_gray.filter(ImageFilter.GaussianBlur(radius=BLUR_RADIUS))
-    blurred_gray = np.asarray(pil_gray, dtype=np.uint8) * land_mask
+    blurred_gray = np.asarray(pil_gray, dtype=np.uint8) * projection.land_mask
     styled_gray = _stylize_heatmap_gray(_preserve_local_maxima(base_gray, blurred_gray))
     peak_floor = np.where(base_gray >= PEAK_BOOST_THRESHOLD * 255.0, styled_gray, 0)
-    styled_gray = (np.maximum(_smooth_styled_heatmap_gray(styled_gray), peak_floor) * land_mask).astype(np.uint8)
+    styled_gray = (np.maximum(_smooth_styled_heatmap_gray(styled_gray), peak_floor) * projection.land_mask).astype(np.uint8)
     rgba = _COLOR_RAMP_LOOKUP[styled_gray]
 
     buf = BytesIO()

--- a/backend/heatmap.py
+++ b/backend/heatmap.py
@@ -17,8 +17,8 @@ if TYPE_CHECKING:
 
     from .scoring import CellScorePoint
 
-WIDTH = 3584
-HEIGHT = 1792
+WIDTH = 2560
+HEIGHT = 1280
 BLUR_RADIUS = 7  # px — preserves more local structure while still showing broad regions
 DETAIL_PRESERVE_THRESHOLD = 0.35
 DETAIL_PRESERVE_STRENGTH = 0.9
@@ -165,7 +165,8 @@ def render_heatmap_png_from_projection(projection: HeatmapProjection, scores: np
     rgba = _COLOR_RAMP_LOOKUP[styled_gray]
 
     buf = BytesIO()
-    Image.fromarray(rgba, mode="RGBA").save(buf, format="PNG", compress_level=4)
+    # Lower PNG compression trades a small size increase for materially less CPU per request.
+    Image.fromarray(rgba, mode="RGBA").save(buf, format="PNG", compress_level=1)
     return buf.getvalue()
 
 

--- a/backend/launcher.py
+++ b/backend/launcher.py
@@ -38,10 +38,20 @@ def ensure_climate_database() -> None:
     """Optionally build the climate database before the app imports its runtime repository."""
     database_path = resolve_climate_database_path()
     if database_path.exists():
-        logger.info("startup_db outcome=found path=%s", database_path)
+        logger.info(
+            "climate database ready", extra={"event": "startup_db", "outcome": "found", "path": str(database_path)}
+        )
         return
     if not resolve_build_climate_db_if_missing():
-        logger.info("startup_db outcome=missing_using_stub path=%s bootstrap=disabled", database_path)
+        logger.info(
+            "climate database missing; using stub data",
+            extra={
+                "event": "startup_db",
+                "outcome": "missing_using_stub",
+                "path": str(database_path),
+                "bootstrap": "disabled",
+            },
+        )
         return
 
     resolution_name = resolve_climate_resolution()
@@ -56,18 +66,26 @@ def ensure_climate_database() -> None:
     database_path.parent.mkdir(parents=True, exist_ok=True)
     cache_dir.mkdir(parents=True, exist_ok=True)
     logger.info(
-        "startup_bootstrap outcome=building_climate_db path=%s resolution=%s cache_dir=%s",
-        database_path,
-        resolution.name,
-        cache_dir,
+        "building climate database",
+        extra={
+            "event": "startup_bootstrap",
+            "outcome": "building_climate_db",
+            "path": str(database_path),
+            "resolution": resolution.name,
+            "cache_dir": str(cache_dir),
+        },
     )
     build_worldclim_database(output_path=database_path, cache_dir=cache_dir, resolution=resolution)
     validation = validate_climate_database(database_path, resolution=resolution)
     logger.info(
-        "startup_bootstrap outcome=ready_climate_db path=%s rows=%s cities=%s",
-        database_path,
-        validation.row_count,
-        validation.city_count,
+        "climate database ready",
+        extra={
+            "event": "startup_bootstrap",
+            "outcome": "ready_climate_db",
+            "path": str(database_path),
+            "row_count": validation.row_count,
+            "city_count": validation.city_count,
+        },
     )
 
 
@@ -75,9 +93,14 @@ def main() -> None:
     """Launch the app server after any requested climate bootstrap work."""
     args = parse_args()
     reload = resolve_reload() and not args.no_reload
-    logger.info("startup phase=begin host=%s port=%s reload=%s", args.host, args.port, reload)
+    logger.info(
+        "startup begin",
+        extra={"event": "startup", "phase": "begin", "host": args.host, "port": args.port, "reload": reload},
+    )
     ensure_climate_database()
-    logger.info("startup phase=starting_server host=%s port=%s", args.host, args.port)
+    logger.info(
+        "starting server", extra={"event": "startup", "phase": "starting_server", "host": args.host, "port": args.port}
+    )
     uvicorn.run("backend.main:app", host=args.host, port=args.port, reload=reload, access_log=False, log_config=None)
 
 

--- a/backend/logging_config.py
+++ b/backend/logging_config.py
@@ -6,9 +6,31 @@ import os
 import sys
 from datetime import UTC, datetime
 
+_RAILWAY_LEVEL_NAMES = {
+    logging.DEBUG: "debug",
+    logging.INFO: "info",
+    logging.WARNING: "warn",
+    logging.ERROR: "error",
+    logging.CRITICAL: "error",
+}
+_LOG_RECORD_DEFAULTS = frozenset(logging.makeLogRecord({}).__dict__)
 
-def _is_railway() -> bool:
+
+def is_railway_environment() -> bool:
+    """Return whether the app is running inside Railway."""
     return os.getenv("RAILWAY_ENVIRONMENT") is not None or os.getenv("RAILWAY_SERVICE_NAME") is not None
+
+
+def _serialize_log_value(value: object) -> object:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, tuple):
+        return [_serialize_log_value(item) for item in value]
+    if isinstance(value, list):
+        return [_serialize_log_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _serialize_log_value(item) for key, item in value.items()}
+    return str(value)
 
 
 class _JSONFormatter(logging.Formatter):
@@ -16,11 +38,15 @@ class _JSONFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         entry: dict[str, object] = {
-            "level": record.levelname.lower(),
+            "level": _RAILWAY_LEVEL_NAMES.get(record.levelno, "info"),
             "message": record.getMessage(),
             "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
             "logger": record.name,
         }
+        for key, value in record.__dict__.items():
+            if key in _LOG_RECORD_DEFAULTS or key.startswith("_"):
+                continue
+            entry[key] = _serialize_log_value(value)
         if record.exc_info:
             entry["error"] = self.formatException(record.exc_info)
         return json.dumps(entry, ensure_ascii=False, separators=(",", ":"))
@@ -34,7 +60,7 @@ def _build_handler(level: int) -> logging.Handler:
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(level)
 
-    if _is_railway():
+    if is_railway_environment():
         handler.setFormatter(_JSONFormatter())
     else:
         handler.setFormatter(logging.Formatter(_PLAIN_FORMAT, datefmt=_PLAIN_DATEFMT))

--- a/backend/main.py
+++ b/backend/main.py
@@ -288,8 +288,7 @@ def create_app(
     score_cache = _ScoreResponseCache(SCORE_CACHE_SIZE)
     preload_repository(repository)
 
-    # Pre-warm cache with default preferences so the load-triggered POST on first page
-    # visit hits a cache entry rather than doing a full 5s computation cold.
+    # Pre-warm default scores so the page-load HTMX POST hits cache instead of paying the cold path.
     try:
         default_prefs = PreferenceInputs(**{f.name: f.value for f in DEFAULT_PREFERENCES})
         score_cache.set(_score_cache_key(default_prefs), build_score_response(repository, default_prefs))

--- a/backend/main.py
+++ b/backend/main.py
@@ -60,6 +60,7 @@ class _ScoreResponseCache:
     def __init__(self, max_entries: int) -> None:
         self.max_entries = max_entries
         self._entries: OrderedDict[tuple[int, int, int, int, int], ScoreResponse] = OrderedDict()
+        self._inflight: dict[tuple[int, int, int, int, int], threading.Event] = {}
         self._lock = threading.Lock()
 
     def get(self, key: tuple[int, int, int, int, int]) -> ScoreResponse | None:
@@ -82,17 +83,34 @@ class _ScoreResponseCache:
         key: tuple[int, int, int, int, int],
         build: Callable[[], ScoreResponse],
     ) -> ScoreResponse:
-        with self._lock:
-            response = self._entries.get(key)
-            if response is not None:
-                self._entries.move_to_end(key)
-                return response
+        while True:
+            with self._lock:
+                response = self._entries.get(key)
+                if response is not None:
+                    self._entries.move_to_end(key)
+                    return response
 
+                inflight = self._inflight.get(key)
+                if inflight is None:
+                    inflight = threading.Event()
+                    self._inflight[key] = inflight
+                    break
+
+            inflight.wait()
+
+        try:
             response = build()
+        except Exception:
+            with self._lock:
+                self._inflight.pop(key).set()
+            raise
+
+        with self._lock:
             self._entries[key] = response
             self._entries.move_to_end(key)
             if len(self._entries) > self.max_entries:
                 self._entries.popitem(last=False)
+            self._inflight.pop(key).set()
             return response
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections import OrderedDict
 from dataclasses import asdict
 from pathlib import Path
 from time import perf_counter
@@ -47,6 +48,28 @@ templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 logger = logging.getLogger(__name__)
 CLIENT_ERROR_STATUS_MIN = 400
 SERVER_ERROR_STATUS_MIN = 500
+SCORE_CACHE_SIZE = 16
+
+
+class _ScoreResponseCache:
+    """Avoid recomputing identical score requests within one worker."""
+
+    def __init__(self, max_entries: int) -> None:
+        self.max_entries = max_entries
+        self._entries: OrderedDict[tuple[int, int, int, int, int], ScoreResponse] = OrderedDict()
+
+    def get(self, key: tuple[int, int, int, int, int]) -> ScoreResponse | None:
+        response = self._entries.get(key)
+        if response is None:
+            return None
+        self._entries.move_to_end(key)
+        return response
+
+    def set(self, key: tuple[int, int, int, int, int], response: ScoreResponse) -> None:
+        self._entries[key] = response
+        self._entries.move_to_end(key)
+        if len(self._entries) > self.max_entries:
+            self._entries.popitem(last=False)
 
 
 class _SupportsProbeRepository(Protocol):
@@ -102,9 +125,40 @@ def preload_repository(repository: ClimateRepository) -> None:
         repository.get_indexed_cities()
         if hasattr(repository, "get_heatmap_projection"):
             repository.get_heatmap_projection()
-        logger.info("startup_preload outcome=ok repository=%s", type(repository).__name__)
+        logger.info(
+            "repository preload finished",
+            extra={"event": "startup_preload", "outcome": "ok", "repository": type(repository).__name__},
+        )
     except ClimateDataError as error:
-        logger.warning("startup_preload outcome=skipped detail=%s", error)
+        logger.warning(
+            "repository preload skipped",
+            extra={"event": "startup_preload", "outcome": "skipped", "detail": str(error)},
+        )
+
+
+def _score_cache_key(preferences: PreferenceInputs) -> tuple[int, int, int, int, int]:
+    return (
+        preferences.preferred_day_temperature,
+        preferences.summer_heat_limit,
+        preferences.winter_cold_limit,
+        preferences.dryness_preference,
+        preferences.sunshine_preference,
+    )
+
+
+def _score_response_from_cache_or_repository(
+    score_cache: _ScoreResponseCache,
+    repository: ClimateRepository,
+    preferences: PreferenceInputs,
+) -> ScoreResponse:
+    cache_key = _score_cache_key(preferences)
+    cached_response = score_cache.get(cache_key)
+    if cached_response is not None:
+        return cached_response
+
+    response = build_score_response(repository, preferences)
+    score_cache.set(cache_key, response)
+    return response
 
 
 def probe_preferences_dependency(
@@ -157,31 +211,41 @@ def _attach_http_request_logging(app: FastAPI) -> None:
         except Exception:
             client, query, scheme, http_version, content_length = _request_log_context(request)
             logger.exception(
-                "http_request outcome=error method=%s path=%s query=%s client=%s scheme=%s http_version=%s bytes=%s duration_ms=%.2f",
-                request.method,
-                request.url.path,
-                query,
-                client,
-                scheme,
-                http_version,
-                content_length,
-                (perf_counter() - started) * 1000,
+                "http request failed",
+                extra={
+                    "event": "http_request",
+                    "outcome": "error",
+                    "method": request.method,
+                    "path": request.url.path,
+                    "query": query,
+                    "httpStatus": 500,
+                    "srcIp": client,
+                    "scheme": scheme,
+                    "httpVersion": http_version,
+                    "txBytes": content_length,
+                    "responseTime": round((perf_counter() - started) * 1000, 2),
+                    "host": request.headers.get("host", "-"),
+                },
             )
             raise
 
         client, query, scheme, http_version, content_length = _request_log_context(request, response)
         logger.info(
-            "http_request outcome=%s method=%s path=%s query=%s status=%d client=%s scheme=%s http_version=%s bytes=%s duration_ms=%.2f",
-            _request_outcome(response.status_code),
-            request.method,
-            request.url.path,
-            query,
-            response.status_code,
-            client,
-            scheme,
-            http_version,
-            content_length,
-            (perf_counter() - started) * 1000,
+            "http request finished",
+            extra={
+                "event": "http_request",
+                "outcome": _request_outcome(response.status_code),
+                "method": request.method,
+                "path": request.url.path,
+                "query": query,
+                "httpStatus": response.status_code,
+                "srcIp": client,
+                "scheme": scheme,
+                "httpVersion": http_version,
+                "txBytes": content_length,
+                "responseTime": round((perf_counter() - started) * 1000, 2),
+                "host": request.headers.get("host", "-"),
+            },
         )
         return response
 
@@ -205,15 +269,8 @@ def create_app(
     app.state.limiter = limiter
     app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
     repository = climate_repository or build_default_climate_repository(resolve_climate_database_path())
+    score_cache = _ScoreResponseCache(SCORE_CACHE_SIZE)
     preload_repository(repository)
-
-    initial_scores: ScoreResponse | None = None
-    try:
-        default_prefs = PreferenceInputs(**{f.name: f.value for f in DEFAULT_PREFERENCES})
-        initial_scores = build_score_response(repository, default_prefs)
-        logger.info("startup_default_scores outcome=ok cities=%d", len(initial_scores.get("scores", [])))
-    except ClimateDataError:
-        logger.warning("startup_default_scores outcome=skipped")
 
     app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
@@ -226,16 +283,27 @@ def create_app(
         return templates.TemplateResponse(
             request=request,
             name="index.html",
-            context={**build_index_context(), "initial_scores": initial_scores},
+            context=build_index_context(),
         )
 
     @app.post("/score")
     @limiter.limit("30/minute")
     async def score(request: Request, preferences: Annotated[PreferenceInputs, Form()]) -> ScoreResponse:
         try:
-            return build_score_response(repository, preferences)
+            return _score_response_from_cache_or_repository(score_cache, repository, preferences)
         except ClimateDataError as error:
-            logger.exception("score_request outcome=error")
+            logger.exception(
+                "score request failed",
+                extra={
+                    "event": "score_request",
+                    "outcome": "error",
+                    "preferred_day_temperature": preferences.preferred_day_temperature,
+                    "summer_heat_limit": preferences.summer_heat_limit,
+                    "winter_cold_limit": preferences.winter_cold_limit,
+                    "dryness_preference": preferences.dryness_preference,
+                    "sunshine_preference": preferences.sunshine_preference,
+                },
+            )
             raise HTTPException(status_code=503, detail=str(error)) from error
 
     @app.get("/probe")
@@ -255,7 +323,10 @@ def create_app(
                 return ProbeResponse()
             climate_matrix = probe_repository.get_climate_matrix()
         except ClimateDataError as error:
-            logger.exception("probe_request outcome=error")
+            logger.exception(
+                "probe request failed",
+                extra={"event": "probe_request", "outcome": "error", "lat": lat, "lon": lon},
+            )
             raise HTTPException(status_code=503, detail=str(error)) from error
         breakdown = score_matrix_row_breakdown(climate_matrix, row_index, preferences)
         return build_probe_response(breakdown)

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from dataclasses import asdict
 from pathlib import Path
 from time import perf_counter
-from typing import TYPE_CHECKING, Annotated, Callable, Protocol, cast
+from typing import TYPE_CHECKING, Annotated, Protocol, cast
 
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
 from fastapi.exceptions import RequestValidationError
@@ -36,6 +36,8 @@ from backend.scoring import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from starlette.middleware.base import RequestResponseEndpoint
 
     from backend.scoring import ClimateMatrix

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import logging
+import threading
 from collections import OrderedDict
 from dataclasses import asdict
 from pathlib import Path
 from time import perf_counter
-from typing import TYPE_CHECKING, Annotated, Protocol, cast
+from typing import TYPE_CHECKING, Annotated, Callable, Protocol, cast
 
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
 from fastapi.exceptions import RequestValidationError
@@ -57,19 +58,40 @@ class _ScoreResponseCache:
     def __init__(self, max_entries: int) -> None:
         self.max_entries = max_entries
         self._entries: OrderedDict[tuple[int, int, int, int, int], ScoreResponse] = OrderedDict()
+        self._lock = threading.Lock()
 
     def get(self, key: tuple[int, int, int, int, int]) -> ScoreResponse | None:
-        response = self._entries.get(key)
-        if response is None:
-            return None
-        self._entries.move_to_end(key)
-        return response
+        with self._lock:
+            response = self._entries.get(key)
+            if response is None:
+                return None
+            self._entries.move_to_end(key)
+            return response
 
     def set(self, key: tuple[int, int, int, int, int], response: ScoreResponse) -> None:
-        self._entries[key] = response
-        self._entries.move_to_end(key)
-        if len(self._entries) > self.max_entries:
-            self._entries.popitem(last=False)
+        with self._lock:
+            self._entries[key] = response
+            self._entries.move_to_end(key)
+            if len(self._entries) > self.max_entries:
+                self._entries.popitem(last=False)
+
+    def get_or_set(
+        self,
+        key: tuple[int, int, int, int, int],
+        build: Callable[[], ScoreResponse],
+    ) -> ScoreResponse:
+        with self._lock:
+            response = self._entries.get(key)
+            if response is not None:
+                self._entries.move_to_end(key)
+                return response
+
+            response = build()
+            self._entries[key] = response
+            self._entries.move_to_end(key)
+            if len(self._entries) > self.max_entries:
+                self._entries.popitem(last=False)
+            return response
 
 
 class _SupportsProbeRepository(Protocol):
@@ -152,13 +174,7 @@ def _score_response_from_cache_or_repository(
     preferences: PreferenceInputs,
 ) -> ScoreResponse:
     cache_key = _score_cache_key(preferences)
-    cached_response = score_cache.get(cache_key)
-    if cached_response is not None:
-        return cached_response
-
-    response = build_score_response(repository, preferences)
-    score_cache.set(cache_key, response)
-    return response
+    return score_cache.get_or_set(cache_key, lambda: build_score_response(repository, preferences))
 
 
 def probe_preferences_dependency(

--- a/backend/main.py
+++ b/backend/main.py
@@ -272,6 +272,15 @@ def create_app(
     score_cache = _ScoreResponseCache(SCORE_CACHE_SIZE)
     preload_repository(repository)
 
+    # Pre-warm cache with default preferences so the load-triggered POST on first page
+    # visit hits a cache entry rather than doing a full 5s computation cold.
+    try:
+        default_prefs = PreferenceInputs(**{f.name: f.value for f in DEFAULT_PREFERENCES})
+        score_cache.set(_score_cache_key(default_prefs), build_score_response(repository, default_prefs))
+        logger.info("startup default score cached", extra={"event": "startup_default_score", "outcome": "ok"})
+    except ClimateDataError:
+        logger.warning("startup default score skipped", extra={"event": "startup_default_score", "outcome": "skipped"})
+
     app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
     @app.get("/health")

--- a/backend/score_service.py
+++ b/backend/score_service.py
@@ -275,18 +275,21 @@ def _log_score_timings(
     outcome: str,
 ) -> None:
     logger.info(
-        "score_request outcome=%s total_ms=%.2f cells_ms=%.2f cities_ms=%.2f scoring_ms=%.2f normalize_ms=%.2f ranking_ms=%.2f heatmap_ms=%.2f climate_cells=%d cities=%d ranked_cities=%d",
-        outcome,
-        timings.total_ms,
-        timings.cells_ms,
-        timings.cities_ms,
-        timings.scoring_ms,
-        timings.normalize_ms,
-        timings.ranking_ms,
-        timings.heatmap_ms,
-        climate_cell_count,
-        city_count,
-        ranked_city_count,
+        "score request finished",
+        extra={
+            "event": "score_request",
+            "outcome": outcome,
+            "total_ms": timings.total_ms,
+            "cells_ms": timings.cells_ms,
+            "cities_ms": timings.cities_ms,
+            "scoring_ms": timings.scoring_ms,
+            "normalize_ms": timings.normalize_ms,
+            "ranking_ms": timings.ranking_ms,
+            "heatmap_ms": timings.heatmap_ms,
+            "climate_cells": climate_cell_count,
+            "cities": city_count,
+            "ranked_cities": ranked_city_count,
+        },
     )
 
 

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, TypedDict
 
 import numpy as np
@@ -100,6 +100,13 @@ class ClimateMatrix:
     temperature_max_c: NDArray[np.float32]
     precipitation_mm: NDArray[np.float32]
     cloud_cover_pct: NDArray[np.uint8]
+    typical_highs_c: NDArray[np.float32] = field(default_factory=lambda: np.array([], dtype=np.float32))
+    hottest_month_highs_c: NDArray[np.float32] = field(default_factory=lambda: np.array([], dtype=np.float32))
+    coldest_month_lows_c: NDArray[np.float32] = field(default_factory=lambda: np.array([], dtype=np.float32))
+    median_precipitation_mm: NDArray[np.float32] = field(default_factory=lambda: np.array([], dtype=np.float32))
+    wettest_precipitation_mm: NDArray[np.float32] = field(default_factory=lambda: np.array([], dtype=np.float32))
+    average_cloud_cover_pct: NDArray[np.float32] = field(default_factory=lambda: np.array([], dtype=np.float32))
+    gloomiest_cloud_cover_pct: NDArray[np.float32] = field(default_factory=lambda: np.array([], dtype=np.float32))
 
     def __post_init__(self) -> None:
         """Reject malformed matrix shapes before they reach the scorer."""
@@ -127,6 +134,76 @@ class ClimateMatrix:
 
         if self.cloud_cover_pct.shape != (cell_count, MONTHS_PER_YEAR):
             msg = "cloud_cover_pct must be shaped (cells, 12)"
+            raise ValueError(msg)
+
+        if self.typical_highs_c.shape == (0,):
+            object.__setattr__(
+                self,
+                "typical_highs_c",
+                np.median(self.temperature_max_c, axis=1).astype(np.float32, copy=False),
+            )
+        elif self.typical_highs_c.shape != (cell_count,):
+            msg = "typical_highs_c must align with latitudes"
+            raise ValueError(msg)
+
+        if self.hottest_month_highs_c.shape == (0,):
+            object.__setattr__(
+                self,
+                "hottest_month_highs_c",
+                np.max(self.temperature_max_c, axis=1).astype(np.float32, copy=False),
+            )
+        elif self.hottest_month_highs_c.shape != (cell_count,):
+            msg = "hottest_month_highs_c must align with latitudes"
+            raise ValueError(msg)
+
+        if self.coldest_month_lows_c.shape == (0,):
+            object.__setattr__(
+                self,
+                "coldest_month_lows_c",
+                np.min(self.temperature_min_c, axis=1).astype(np.float32, copy=False),
+            )
+        elif self.coldest_month_lows_c.shape != (cell_count,):
+            msg = "coldest_month_lows_c must align with latitudes"
+            raise ValueError(msg)
+
+        if self.median_precipitation_mm.shape == (0,):
+            object.__setattr__(
+                self,
+                "median_precipitation_mm",
+                np.median(self.precipitation_mm, axis=1).astype(np.float32, copy=False),
+            )
+        elif self.median_precipitation_mm.shape != (cell_count,):
+            msg = "median_precipitation_mm must align with latitudes"
+            raise ValueError(msg)
+
+        if self.wettest_precipitation_mm.shape == (0,):
+            object.__setattr__(
+                self,
+                "wettest_precipitation_mm",
+                np.max(self.precipitation_mm, axis=1).astype(np.float32, copy=False),
+            )
+        elif self.wettest_precipitation_mm.shape != (cell_count,):
+            msg = "wettest_precipitation_mm must align with latitudes"
+            raise ValueError(msg)
+
+        if self.average_cloud_cover_pct.shape == (0,):
+            object.__setattr__(
+                self,
+                "average_cloud_cover_pct",
+                np.rint(np.mean(self.cloud_cover_pct.astype(np.float32), axis=1)).astype(np.float32, copy=False),
+            )
+        elif self.average_cloud_cover_pct.shape != (cell_count,):
+            msg = "average_cloud_cover_pct must align with latitudes"
+            raise ValueError(msg)
+
+        if self.gloomiest_cloud_cover_pct.shape == (0,):
+            object.__setattr__(
+                self,
+                "gloomiest_cloud_cover_pct",
+                np.max(self.cloud_cover_pct, axis=1).astype(np.float32, copy=False),
+            )
+        elif self.gloomiest_cloud_cover_pct.shape != (cell_count,):
+            msg = "gloomiest_cloud_cover_pct must align with latitudes"
             raise ValueError(msg)
 
     @classmethod
@@ -386,15 +463,13 @@ def score_climate_matrix(climate_matrix: ClimateMatrix, preferences: PreferenceI
         preferences.dryness_preference,
         preferences.sunshine_preference,
     )
-    typical_highs = np.median(climate_matrix.temperature_max_c, axis=1)
-    hottest_month_highs = np.max(climate_matrix.temperature_max_c, axis=1)
-    coldest_month_lows = np.min(climate_matrix.temperature_min_c, axis=1)
-
-    ideal_distance = np.maximum(np.abs(typical_highs - preferred_day_temperature) - TEMPERATURE_COMFORT_BAND_C, 0.0)
+    ideal_distance = np.maximum(
+        np.abs(climate_matrix.typical_highs_c - preferred_day_temperature) - TEMPERATURE_COMFORT_BAND_C, 0.0
+    )
     ideal_scores = np.clip(1.0 - (ideal_distance / TEMPERATURE_IDEAL_SLOPE_C), 0.0, 1.0)
-    heat_excess = np.maximum(hottest_month_highs - summer_heat_limit, 0.0)
+    heat_excess = np.maximum(climate_matrix.hottest_month_highs_c - summer_heat_limit, 0.0)
     heat_scores = np.clip(1.0 - (heat_excess / TEMPERATURE_LIMIT_SLOPE_C), 0.0, 1.0)
-    cold_excess = np.maximum(winter_cold_limit - coldest_month_lows, 0.0)
+    cold_excess = np.maximum(winter_cold_limit - climate_matrix.coldest_month_lows_c, 0.0)
     cold_scores = np.clip(1.0 - (cold_excess / TEMPERATURE_LIMIT_SLOPE_C), 0.0, 1.0)
     temperature_scores = (
         ideal_scores**TEMPERATURE_IDEAL_WEIGHT
@@ -402,11 +477,13 @@ def score_climate_matrix(climate_matrix: ClimateMatrix, preferences: PreferenceI
         * cold_scores**TEMPERATURE_COLD_WEIGHT
     ).astype(np.float32, copy=False)
 
-    median_precipitation = np.median(climate_matrix.precipitation_mm, axis=1)
-    wettest_precipitation = np.max(climate_matrix.precipitation_mm, axis=1)
-    typical_rain_scores = np.clip(1.0 - (median_precipitation / SATURATING_MONTHLY_RAIN_MM) * dryness_ratio, 0.0, 1.0)
+    typical_rain_scores = np.clip(
+        1.0 - (climate_matrix.median_precipitation_mm / SATURATING_MONTHLY_RAIN_MM) * dryness_ratio,
+        0.0,
+        1.0,
+    )
     wettest_month_scores = np.clip(
-        1.0 - (wettest_precipitation / SATURATING_WETTEST_MONTH_RAIN_MM) * dryness_ratio,
+        1.0 - (climate_matrix.wettest_precipitation_mm / SATURATING_WETTEST_MONTH_RAIN_MM) * dryness_ratio,
         0.0,
         1.0,
     )
@@ -415,17 +492,15 @@ def score_climate_matrix(climate_matrix: ClimateMatrix, preferences: PreferenceI
         * np.maximum(wettest_month_scores, MULTIPLICATIVE_SCORE_FLOOR) ** PRECIPITATION_PROFILE_PEAK_WEIGHT
     ).astype(np.float32, copy=False)
 
-    average_cloud_cover = np.rint(np.mean(climate_matrix.cloud_cover_pct.astype(np.float32), axis=1)).astype(np.float32)
-    gloomiest_cloud_cover = np.max(climate_matrix.cloud_cover_pct, axis=1).astype(np.float32)
-    average_excess_ratio = (average_cloud_cover - tolerated_cloud_cover) / cloud_denominator
+    average_excess_ratio = (climate_matrix.average_cloud_cover_pct - tolerated_cloud_cover) / cloud_denominator
     average_sun_scores = np.where(
-        average_cloud_cover <= tolerated_cloud_cover,
+        climate_matrix.average_cloud_cover_pct <= tolerated_cloud_cover,
         1.0,
         np.clip(1.0 - average_excess_ratio**2, 0.0, 1.0),
     )
-    gloom_excess_ratio = (gloomiest_cloud_cover - tolerated_cloud_cover) / cloud_denominator
+    gloom_excess_ratio = (climate_matrix.gloomiest_cloud_cover_pct - tolerated_cloud_cover) / cloud_denominator
     gloomiest_sun_scores = np.where(
-        gloomiest_cloud_cover <= tolerated_cloud_cover,
+        climate_matrix.gloomiest_cloud_cover_pct <= tolerated_cloud_cover,
         1.0,
         np.clip(1.0 - gloom_excess_ratio**2, 0.0, 1.0),
     )

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -112,6 +112,44 @@ class ClimateMatrix:
         """Reject malformed matrix shapes before they reach the scorer."""
         cell_count = self.latitudes.shape[0]
 
+        self._validate_base_shapes(cell_count)
+        self._ensure_derived_vector(
+            "typical_highs_c",
+            np.median(self.temperature_max_c, axis=1).astype(np.float32, copy=False),
+            cell_count,
+        )
+        self._ensure_derived_vector(
+            "hottest_month_highs_c",
+            np.max(self.temperature_max_c, axis=1).astype(np.float32, copy=False),
+            cell_count,
+        )
+        self._ensure_derived_vector(
+            "coldest_month_lows_c",
+            np.min(self.temperature_min_c, axis=1).astype(np.float32, copy=False),
+            cell_count,
+        )
+        self._ensure_derived_vector(
+            "median_precipitation_mm",
+            np.median(self.precipitation_mm, axis=1).astype(np.float32, copy=False),
+            cell_count,
+        )
+        self._ensure_derived_vector(
+            "wettest_precipitation_mm",
+            np.max(self.precipitation_mm, axis=1).astype(np.float32, copy=False),
+            cell_count,
+        )
+        self._ensure_derived_vector(
+            "average_cloud_cover_pct",
+            np.rint(np.mean(self.cloud_cover_pct.astype(np.float32), axis=1)).astype(np.float32, copy=False),
+            cell_count,
+        )
+        self._ensure_derived_vector(
+            "gloomiest_cloud_cover_pct",
+            np.max(self.cloud_cover_pct, axis=1).astype(np.float32, copy=False),
+            cell_count,
+        )
+
+    def _validate_base_shapes(self, cell_count: int) -> None:
         if self.longitudes.shape != (cell_count,):
             msg = "longitudes must align with latitudes"
             raise ValueError(msg)
@@ -136,74 +174,14 @@ class ClimateMatrix:
             msg = "cloud_cover_pct must be shaped (cells, 12)"
             raise ValueError(msg)
 
-        if self.typical_highs_c.shape == (0,):
-            object.__setattr__(
-                self,
-                "typical_highs_c",
-                np.median(self.temperature_max_c, axis=1).astype(np.float32, copy=False),
-            )
-        elif self.typical_highs_c.shape != (cell_count,):
-            msg = "typical_highs_c must align with latitudes"
-            raise ValueError(msg)
+    def _ensure_derived_vector(self, attribute: str, derived: NDArray[np.float32], cell_count: int) -> None:
+        current = getattr(self, attribute)
+        if current.shape == (0,):
+            object.__setattr__(self, attribute, derived)
+            return
 
-        if self.hottest_month_highs_c.shape == (0,):
-            object.__setattr__(
-                self,
-                "hottest_month_highs_c",
-                np.max(self.temperature_max_c, axis=1).astype(np.float32, copy=False),
-            )
-        elif self.hottest_month_highs_c.shape != (cell_count,):
-            msg = "hottest_month_highs_c must align with latitudes"
-            raise ValueError(msg)
-
-        if self.coldest_month_lows_c.shape == (0,):
-            object.__setattr__(
-                self,
-                "coldest_month_lows_c",
-                np.min(self.temperature_min_c, axis=1).astype(np.float32, copy=False),
-            )
-        elif self.coldest_month_lows_c.shape != (cell_count,):
-            msg = "coldest_month_lows_c must align with latitudes"
-            raise ValueError(msg)
-
-        if self.median_precipitation_mm.shape == (0,):
-            object.__setattr__(
-                self,
-                "median_precipitation_mm",
-                np.median(self.precipitation_mm, axis=1).astype(np.float32, copy=False),
-            )
-        elif self.median_precipitation_mm.shape != (cell_count,):
-            msg = "median_precipitation_mm must align with latitudes"
-            raise ValueError(msg)
-
-        if self.wettest_precipitation_mm.shape == (0,):
-            object.__setattr__(
-                self,
-                "wettest_precipitation_mm",
-                np.max(self.precipitation_mm, axis=1).astype(np.float32, copy=False),
-            )
-        elif self.wettest_precipitation_mm.shape != (cell_count,):
-            msg = "wettest_precipitation_mm must align with latitudes"
-            raise ValueError(msg)
-
-        if self.average_cloud_cover_pct.shape == (0,):
-            object.__setattr__(
-                self,
-                "average_cloud_cover_pct",
-                np.rint(np.mean(self.cloud_cover_pct.astype(np.float32), axis=1)).astype(np.float32, copy=False),
-            )
-        elif self.average_cloud_cover_pct.shape != (cell_count,):
-            msg = "average_cloud_cover_pct must align with latitudes"
-            raise ValueError(msg)
-
-        if self.gloomiest_cloud_cover_pct.shape == (0,):
-            object.__setattr__(
-                self,
-                "gloomiest_cloud_cover_pct",
-                np.max(self.cloud_cover_pct, axis=1).astype(np.float32, copy=False),
-            )
-        elif self.gloomiest_cloud_cover_pct.shape != (cell_count,):
-            msg = "gloomiest_cloud_cover_pct must align with latitudes"
+        if current.shape != (cell_count,):
+            msg = f"{attribute} must align with latitudes"
             raise ValueError(msg)
 
     @classmethod

--- a/frontend/static/map-core.js
+++ b/frontend/static/map-core.js
@@ -60,6 +60,7 @@ let probeTimer = null;
 let probeCooldownTimer = null;
 let probeController = null;
 let probeTimeoutId = null;
+let probeRequestToken = 0;
 let tooltipHideTimer = null;
 let focusClearTimer = null;
 let focusAnimationFrame = null;

--- a/frontend/static/map-core.js
+++ b/frontend/static/map-core.js
@@ -35,6 +35,8 @@ const FOCUS_PING_MS = 1800;
 const FOCUS_ANIMATION_MS = 900;
 const FOCUS_VISIBILITY_PADDING_PX = 72;
 const CITY_SNAP_RADIUS_PX = 14;
+const PROBE_HOVER_DELAY_MS = 80;
+const PROBE_HOVER_COOLDOWN_MS = 250;
 const PROBE_TIMEOUT_MS = 5000;
 const SCORE_TIMEOUT_MS = 30000;
 const CONTINENT_ORDER = ["Europe", "Asia", "Africa", "North America", "South America", "Oceania"];
@@ -55,6 +57,7 @@ const countryNames = typeof Intl.DisplayNames === "function"
 let mapLoaded = false;
 let pendingResponse = null;
 let probeTimer = null;
+let probeCooldownTimer = null;
 let probeController = null;
 let probeTimeoutId = null;
 let tooltipHideTimer = null;
@@ -125,6 +128,10 @@ function cancelTooltipHideTimer() {
 function abortActiveProbe() {
   clearTimeout(probeTimeoutId);
   if (probeController) probeController.abort();
+}
+
+function cancelProbeCooldown() {
+  clearTimeout(probeCooldownTimer);
 }
 
 function armTooltipHideTimer(delayMs = TOOLTIP_HIDE_DELAY_MS) {

--- a/frontend/static/map-probe.js
+++ b/frontend/static/map-probe.js
@@ -7,7 +7,13 @@ const PROBE_MAX_LATITUDE_INDEX = Math.round(180 / PROBE_GRID_DEGREES) - 1;
 const PROBE_MAX_LONGITUDE_INDEX = Math.round(360 / PROBE_GRID_DEGREES) - 1;
 
 document.addEventListener("input", (event) => {
-  if (event.target.closest("#preferences")) probeCache.clear();
+  if (!event.target.closest("#preferences")) return;
+
+  probeRequestToken += 1;
+  cancelProbeCooldown();
+  abortActiveProbe();
+  probeCache.clear();
+  hideTooltip();
 }, { passive: true });
 
 function getCurrentPreferences() {
@@ -103,6 +109,9 @@ function registerLayerProbeHandlers(layerId, { cursor, header, coordinates = nul
 
   map.on("mouseleave", layerId, () => {
     hoveringLayer = false;
+    probeRequestToken += 1;
+    cancelProbeCooldown();
+    abortActiveProbe();
     map.getCanvas().style.cursor = "";
     hideTooltip();
   });
@@ -160,10 +169,13 @@ function hideTooltip() {
   if (tooltip) tooltip.hidden = true;
 }
 
-function runProbeRequest(cacheKey, params, clientX, clientY, cityHeader, { hideDelayMs = null } = {}) {
+function runProbeRequest(cacheKey, params, clientX, clientY, cityHeader, requestToken, { hideDelayMs = null } = {}) {
+  if (requestToken !== probeRequestToken) return;
+
   abortActiveProbe();
   probeController = new AbortController();
-  probeTimeoutId = setTimeout(() => probeController.abort(), PROBE_TIMEOUT_MS);
+  const timeoutId = setTimeout(() => probeController.abort(), PROBE_TIMEOUT_MS);
+  probeTimeoutId = timeoutId;
 
   fetch(`/probe?${params}`, { signal: probeController.signal })
     .then((response) => {
@@ -171,27 +183,31 @@ function runProbeRequest(cacheKey, params, clientX, clientY, cityHeader, { hideD
       return response.json();
     })
     .then((data) => {
+      if (requestToken !== probeRequestToken) return;
       probeCache.set(cacheKey, data);
       showTooltip(data, clientX, clientY, cityHeader, { hideDelayMs });
     })
     .catch(() => {})
-    .finally(() => clearTimeout(probeTimeoutId));
+    .finally(() => {
+      clearTimeout(timeoutId);
+      if (probeTimeoutId === timeoutId) probeTimeoutId = null;
+    });
 }
 
-function queueProbeRequest(cacheKey, params, clientX, clientY, cityHeader, { hideDelayMs = null, cooldownMs = 0 } = {}) {
+function queueProbeRequest(cacheKey, params, clientX, clientY, cityHeader, requestToken, { hideDelayMs = null, cooldownMs = 0 } = {}) {
   cancelProbeCooldown();
   if (cooldownMs <= 0) {
-    runProbeRequest(cacheKey, params, clientX, clientY, cityHeader, { hideDelayMs });
+    runProbeRequest(cacheKey, params, clientX, clientY, cityHeader, requestToken, { hideDelayMs });
     return;
   }
 
   probeCooldownTimer = setTimeout(
-    () => runProbeRequest(cacheKey, params, clientX, clientY, cityHeader, { hideDelayMs }),
+    () => runProbeRequest(cacheKey, params, clientX, clientY, cityHeader, requestToken, { hideDelayMs }),
     cooldownMs,
   );
 }
 
-function fetchProbe(lat, lon, clientX, clientY, cityHeader = null, { hideDelayMs = null, cooldownMs = 0 } = {}) {
+function fetchProbe(lat, lon, clientX, clientY, cityHeader = null, { hideDelayMs = null, cooldownMs = 0, requestToken = ++probeRequestToken } = {}) {
   const prefs = getCurrentPreferences();
   if (!prefs) return;
 
@@ -202,12 +218,13 @@ function fetchProbe(lat, lon, clientX, clientY, cityHeader = null, { hideDelayMs
   if (cached) {
     cancelProbeCooldown();
     abortActiveProbe();
+    if (requestToken !== probeRequestToken) return;
     showTooltip(cached, clientX, clientY, cityHeader, { hideDelayMs });
     return;
   }
 
   const params = new URLSearchParams({ lat: snapped.lat, lon: snapped.lon, ...prefs });
-  queueProbeRequest(cacheKey, params, clientX, clientY, cityHeader, { hideDelayMs, cooldownMs });
+  queueProbeRequest(cacheKey, params, clientX, clientY, cityHeader, requestToken, { hideDelayMs, cooldownMs });
 }
 
 function scheduleHoverProbe(event) {
@@ -216,11 +233,13 @@ function scheduleHoverProbe(event) {
   clearTimeout(probeTimer);
   probeTimer = setTimeout(() => {
     const snapped = nearestFeatureAtPoint(event.point);
+    const requestToken = ++probeRequestToken;
     if (snapped) {
       map.getCanvas().style.cursor = snapped.cursor;
       fetchProbe(snapped.lat, snapped.lon, event.originalEvent.clientX, event.originalEvent.clientY, snapped.header, {
         hideDelayMs: null,
         cooldownMs: PROBE_HOVER_COOLDOWN_MS,
+        requestToken,
       });
       return;
     }
@@ -229,11 +248,13 @@ function scheduleHoverProbe(event) {
     fetchProbe(event.lngLat.lat, event.lngLat.lng, event.originalEvent.clientX, event.originalEvent.clientY, null, {
       hideDelayMs: null,
       cooldownMs: PROBE_HOVER_COOLDOWN_MS,
+      requestToken,
     });
   }, PROBE_HOVER_DELAY_MS);
 }
 
 function resetTransientMapUi() {
+  probeRequestToken += 1;
   clearTimeout(probeTimer);
   cancelProbeCooldown();
   abortActiveProbe();

--- a/frontend/static/map-probe.js
+++ b/frontend/static/map-probe.js
@@ -160,24 +160,10 @@ function hideTooltip() {
   if (tooltip) tooltip.hidden = true;
 }
 
-function fetchProbe(lat, lon, clientX, clientY, cityHeader = null, { hideDelayMs = null } = {}) {
-  const prefs = getCurrentPreferences();
-  if (!prefs) return;
-
-  const snapped = snapProbeCoordinate(lat, lon);
-
-  const cacheKey = `${snapped.lat},${snapped.lon},${new URLSearchParams(prefs)}`;
-  const cached = probeCache.get(cacheKey);
-  if (cached) {
-    abortActiveProbe();
-    showTooltip(cached, clientX, clientY, cityHeader, { hideDelayMs });
-    return;
-  }
-
+function runProbeRequest(cacheKey, params, clientX, clientY, cityHeader, { hideDelayMs = null } = {}) {
   abortActiveProbe();
   probeController = new AbortController();
   probeTimeoutId = setTimeout(() => probeController.abort(), PROBE_TIMEOUT_MS);
-  const params = new URLSearchParams({ lat: snapped.lat, lon: snapped.lon, ...prefs });
 
   fetch(`/probe?${params}`, { signal: probeController.signal })
     .then((response) => {
@@ -192,10 +178,41 @@ function fetchProbe(lat, lon, clientX, clientY, cityHeader = null, { hideDelayMs
     .finally(() => clearTimeout(probeTimeoutId));
 }
 
+function queueProbeRequest(cacheKey, params, clientX, clientY, cityHeader, { hideDelayMs = null, cooldownMs = 0 } = {}) {
+  cancelProbeCooldown();
+  if (cooldownMs <= 0) {
+    runProbeRequest(cacheKey, params, clientX, clientY, cityHeader, { hideDelayMs });
+    return;
+  }
+
+  probeCooldownTimer = setTimeout(
+    () => runProbeRequest(cacheKey, params, clientX, clientY, cityHeader, { hideDelayMs }),
+    cooldownMs,
+  );
+}
+
+function fetchProbe(lat, lon, clientX, clientY, cityHeader = null, { hideDelayMs = null, cooldownMs = 0 } = {}) {
+  const prefs = getCurrentPreferences();
+  if (!prefs) return;
+
+  const snapped = snapProbeCoordinate(lat, lon);
+
+  const cacheKey = `${snapped.lat},${snapped.lon},${new URLSearchParams(prefs)}`;
+  const cached = probeCache.get(cacheKey);
+  if (cached) {
+    cancelProbeCooldown();
+    abortActiveProbe();
+    showTooltip(cached, clientX, clientY, cityHeader, { hideDelayMs });
+    return;
+  }
+
+  const params = new URLSearchParams({ lat: snapped.lat, lon: snapped.lon, ...prefs });
+  queueProbeRequest(cacheKey, params, clientX, clientY, cityHeader, { hideDelayMs, cooldownMs });
+}
+
 function scheduleHoverProbe(event) {
   if (hoveringLayer) return;
 
-  hideTooltip();
   clearTimeout(probeTimer);
   probeTimer = setTimeout(() => {
     const snapped = nearestFeatureAtPoint(event.point);
@@ -203,6 +220,7 @@ function scheduleHoverProbe(event) {
       map.getCanvas().style.cursor = snapped.cursor;
       fetchProbe(snapped.lat, snapped.lon, event.originalEvent.clientX, event.originalEvent.clientY, snapped.header, {
         hideDelayMs: null,
+        cooldownMs: PROBE_HOVER_COOLDOWN_MS,
       });
       return;
     }
@@ -210,12 +228,14 @@ function scheduleHoverProbe(event) {
     map.getCanvas().style.cursor = "";
     fetchProbe(event.lngLat.lat, event.lngLat.lng, event.originalEvent.clientX, event.originalEvent.clientY, null, {
       hideDelayMs: null,
+      cooldownMs: PROBE_HOVER_COOLDOWN_MS,
     });
-  }, 80);
+  }, PROBE_HOVER_DELAY_MS);
 }
 
 function resetTransientMapUi() {
   clearTimeout(probeTimer);
+  cancelProbeCooldown();
   abortActiveProbe();
   hideTooltip();
   clearFocusedCity();

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -30,7 +30,7 @@
         <form
           id="preferences"
           hx-post="/score"
-          hx-trigger="input changed delay:300ms"
+          hx-trigger="load, input changed delay:300ms"
           hx-sync="this:replace"
           hx-swap="none"
           hx-request='{"timeout": 30000}'
@@ -93,9 +93,6 @@
     <script src="/static/map-probe.js"></script>
     <script src="/static/map-layers.js"></script>
     <script src="/static/map.js"></script>
-    {% if initial_scores %}
-    <script>window.POGODAPP_INITIAL_SCORES = {{ initial_scores | tojson }};</script>
-    {% endif %}
     <script src="/static/app.js"></script>
   </body>
 </html>

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -505,7 +505,7 @@ def test_score_endpoint_reuses_cached_response_for_identical_preferences() -> No
 
     assert first_response.status_code == 200
     assert second_response.status_code == 200
-    assert call_count == 1
+    assert call_count == 2  # 1 pre-warm (default prefs) + 1 first request (different prefs, cache miss)
 
 
 def test_score_endpoint_evicts_oldest_cached_preferences_after_cache_limit() -> None:
@@ -536,7 +536,7 @@ def test_score_endpoint_evicts_oldest_cached_preferences_after_cache_limit() -> 
 
     assert repeated_first.status_code == 200
     assert newest_repeat.status_code == 200
-    assert call_count == 18
+    assert call_count == 19  # 1 pre-warm + 17 unique requests + repeated_first evicted by pre-warm occupying a slot
 
 
 def test_dryness_preference_penalizes_rainier_cells() -> None:

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -14,6 +14,9 @@ from backend.scoring import ClimateCell, ClimateMatrix, PreferenceInputs, score_
 
 if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
+    from _pytest.monkeypatch import MonkeyPatch
+
+from backend import main as backend_main
 
 
 def _capture_backend_logs() -> tuple[logging.Logger, list[logging.Handler], bool]:
@@ -108,7 +111,7 @@ def test_home_page_renders() -> None:
     assert "POGODAPP" in response.text
     assert "Pick the climate you like and see where it shows up." in response.text
     assert 'hx-post="/score"' in response.text
-    assert 'hx-trigger="input changed delay:300ms"' in response.text
+    assert 'hx-trigger="load, input changed delay:300ms"' in response.text
     assert 'hx-sync="this:replace"' in response.text
     assert 'hx-swap="none"' in response.text
     assert 'id="map-description"' in response.text
@@ -133,6 +136,7 @@ def test_home_page_renders() -> None:
     assert MAP_PROJECTION.name in response.text
     assert "probeGridDegrees" in response.text
     assert str(GRID_DEGREES) in response.text
+    assert "POGODAPP_INITIAL_SCORES" not in response.text
 
 
 def test_home_page_uses_backend_default_preferences() -> None:
@@ -148,6 +152,13 @@ def test_home_page_uses_backend_default_preferences() -> None:
         assert f'max="{preference.maximum}"' in response.text
         assert f'step="{preference.step}"' in response.text
         assert f'value="{preference.value}"' in response.text
+
+
+def test_app_bootstrap_relies_on_htmx_load_trigger_instead_of_manual_submit() -> None:
+    response = client.get("/static/app.js")
+
+    assert response.status_code == 200
+    assert 'window.htmx.trigger(form, "submit")' not in response.text
 
 
 def test_preference_contract_matches_issue_scope() -> None:
@@ -290,8 +301,17 @@ def test_http_requests_are_logged(caplog: LogCaptureFixture) -> None:
         _restore_backend_logs(backend_logger, original_handlers, original_propagate)
 
     assert response.status_code == 200
-    assert "http_request outcome=ok method=GET path=/health query=- status=200" in caplog.text
-    assert "client=testclient scheme=http http_version=1.1" in caplog.text
+    assert caplog.records
+    record = caplog.records[-1]
+    assert record.message == "http request finished"
+    assert record.event == "http_request"
+    assert record.outcome == "ok"
+    assert record.method == "GET"
+    assert record.path == "/health"
+    assert record.httpStatus == 200
+    assert record.srcIp == "testclient"
+    assert record.scheme == "http"
+    assert record.httpVersion == "1.1"
 
 
 def test_http_request_logs_client_errors(caplog: LogCaptureFixture) -> None:
@@ -304,7 +324,13 @@ def test_http_request_logs_client_errors(caplog: LogCaptureFixture) -> None:
         _restore_backend_logs(backend_logger, original_handlers, original_propagate)
 
     assert response.status_code == 404
-    assert "http_request outcome=client_error method=GET path=/missing-route query=- status=404" in caplog.text
+    assert caplog.records
+    record = caplog.records[-1]
+    assert record.message == "http request finished"
+    assert record.event == "http_request"
+    assert record.outcome == "client_error"
+    assert record.path == "/missing-route"
+    assert record.httpStatus == 404
 
 
 def test_http_request_logs_server_errors(caplog: LogCaptureFixture) -> None:
@@ -324,7 +350,13 @@ def test_http_request_logs_server_errors(caplog: LogCaptureFixture) -> None:
         _restore_backend_logs(backend_logger, original_handlers, original_propagate)
 
     assert response.status_code == 503
-    assert "http_request outcome=error method=POST path=/score query=- status=503" in caplog.text
+    assert caplog.records
+    record = caplog.records[-1]
+    assert record.message == "http request finished"
+    assert record.event == "http_request"
+    assert record.outcome == "error"
+    assert record.path == "/score"
+    assert record.httpStatus == 503
 
 
 def test_http_request_logs_uncaught_exceptions(caplog: LogCaptureFixture) -> None:
@@ -345,7 +377,32 @@ def test_http_request_logs_uncaught_exceptions(caplog: LogCaptureFixture) -> Non
         _restore_backend_logs(backend_logger, original_handlers, original_propagate)
 
     assert response.status_code == 500
-    assert "http_request outcome=error method=GET path=/boom query=x=1" in caplog.text
+    assert caplog.records
+    record = caplog.records[-1]
+    assert record.message == "http request failed"
+    assert record.event == "http_request"
+    assert record.outcome == "error"
+    assert record.path == "/boom"
+    assert record.query == "x=1"
+
+
+def test_http_requests_are_logged_on_railway_too(monkeypatch: MonkeyPatch, caplog: LogCaptureFixture) -> None:
+    monkeypatch.setenv("RAILWAY_ENVIRONMENT", "production")
+    railway_client = TestClient(create_app(climate_repository=StubClimateRepository()))
+    backend_logger, original_handlers, original_propagate = _capture_backend_logs()
+
+    try:
+        with caplog.at_level(logging.INFO, logger="backend"):
+            response = railway_client.get("/health")
+    finally:
+        _restore_backend_logs(backend_logger, original_handlers, original_propagate)
+
+    assert response.status_code == 200
+    assert caplog.records
+    record = caplog.records[-1]
+    assert record.event == "http_request"
+    assert record.path == "/health"
+    assert record.httpStatus == 200
 
 
 def test_score_endpoint_accepts_form_encoded_preferences() -> None:
@@ -426,6 +483,60 @@ def test_score_endpoint_is_deterministic_for_the_same_preferences() -> None:
     assert second_response.status_code == 200
     assert first_response.json()["scores"] == second_response.json()["scores"]
     assert first_response.json()["heatmap"] == second_response.json()["heatmap"]
+
+
+def test_score_endpoint_reuses_cached_response_for_identical_preferences() -> None:
+    call_count = 0
+    original_builder = backend_main.build_score_response
+
+    def counted_builder(repository: StubClimateRepository, preferences: PreferenceInputs) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        return original_builder(repository, preferences)
+
+    backend_main.build_score_response = counted_builder
+    cached_client = TestClient(create_app(climate_repository=StubClimateRepository()))
+
+    try:
+        first_response = cached_client.post("/score", data=default_form_data())
+        second_response = cached_client.post("/score", data=default_form_data())
+    finally:
+        backend_main.build_score_response = original_builder
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert call_count == 1
+
+
+def test_score_endpoint_evicts_oldest_cached_preferences_after_cache_limit() -> None:
+    call_count = 0
+    original_builder = backend_main.build_score_response
+
+    def counted_builder(repository: StubClimateRepository, preferences: PreferenceInputs) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        return original_builder(repository, preferences)
+
+    backend_main.build_score_response = counted_builder
+    cached_client = TestClient(create_app(climate_repository=StubClimateRepository()))
+    base_form = default_form_data()
+
+    try:
+        for offset in range(17):
+            response = cached_client.post(
+                "/score",
+                data={**base_form, "dryness_preference": str(offset)},
+            )
+            assert response.status_code == 200
+
+        repeated_first = cached_client.post("/score", data={**base_form, "dryness_preference": "0"})
+        newest_repeat = cached_client.post("/score", data={**base_form, "dryness_preference": "16"})
+    finally:
+        backend_main.build_score_response = original_builder
+
+    assert repeated_first.status_code == 200
+    assert newest_repeat.status_code == 200
+    assert call_count == 18
 
 
 def test_dryness_preference_penalizes_rainier_cells() -> None:

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
     from _pytest.monkeypatch import MonkeyPatch
 
+    from backend.score_service import ScoreResponse
+
+
 from backend import main as backend_main
 
 
@@ -319,14 +322,14 @@ def test_http_requests_are_logged(caplog: LogCaptureFixture) -> None:
     assert caplog.records
     record = caplog.records[-1]
     assert record.message == "http request finished"
-    assert record.event == "http_request"
-    assert record.outcome == "ok"
-    assert record.method == "GET"
-    assert record.path == "/health"
-    assert record.httpStatus == 200
-    assert record.srcIp == "testclient"
-    assert record.scheme == "http"
-    assert record.httpVersion == "1.1"
+    assert record.__dict__["event"] == "http_request"
+    assert record.__dict__["outcome"] == "ok"
+    assert record.__dict__["method"] == "GET"
+    assert record.__dict__["path"] == "/health"
+    assert record.__dict__["httpStatus"] == 200
+    assert record.__dict__["srcIp"] == "testclient"
+    assert record.__dict__["scheme"] == "http"
+    assert record.__dict__["httpVersion"] == "1.1"
 
 
 def test_http_request_logs_client_errors(caplog: LogCaptureFixture) -> None:
@@ -342,10 +345,10 @@ def test_http_request_logs_client_errors(caplog: LogCaptureFixture) -> None:
     assert caplog.records
     record = caplog.records[-1]
     assert record.message == "http request finished"
-    assert record.event == "http_request"
-    assert record.outcome == "client_error"
-    assert record.path == "/missing-route"
-    assert record.httpStatus == 404
+    assert record.__dict__["event"] == "http_request"
+    assert record.__dict__["outcome"] == "client_error"
+    assert record.__dict__["path"] == "/missing-route"
+    assert record.__dict__["httpStatus"] == 404
 
 
 def test_http_request_logs_server_errors(caplog: LogCaptureFixture) -> None:
@@ -368,10 +371,10 @@ def test_http_request_logs_server_errors(caplog: LogCaptureFixture) -> None:
     assert caplog.records
     record = caplog.records[-1]
     assert record.message == "http request finished"
-    assert record.event == "http_request"
-    assert record.outcome == "error"
-    assert record.path == "/score"
-    assert record.httpStatus == 503
+    assert record.__dict__["event"] == "http_request"
+    assert record.__dict__["outcome"] == "error"
+    assert record.__dict__["path"] == "/score"
+    assert record.__dict__["httpStatus"] == 503
 
 
 def test_http_request_logs_uncaught_exceptions(caplog: LogCaptureFixture) -> None:
@@ -395,10 +398,10 @@ def test_http_request_logs_uncaught_exceptions(caplog: LogCaptureFixture) -> Non
     assert caplog.records
     record = caplog.records[-1]
     assert record.message == "http request failed"
-    assert record.event == "http_request"
-    assert record.outcome == "error"
-    assert record.path == "/boom"
-    assert record.query == "x=1"
+    assert record.__dict__["event"] == "http_request"
+    assert record.__dict__["outcome"] == "error"
+    assert record.__dict__["path"] == "/boom"
+    assert record.__dict__["query"] == "x=1"
 
 
 def test_http_requests_are_logged_on_railway_too(monkeypatch: MonkeyPatch, caplog: LogCaptureFixture) -> None:
@@ -415,9 +418,9 @@ def test_http_requests_are_logged_on_railway_too(monkeypatch: MonkeyPatch, caplo
     assert response.status_code == 200
     assert caplog.records
     record = caplog.records[-1]
-    assert record.event == "http_request"
-    assert record.path == "/health"
-    assert record.httpStatus == 200
+    assert record.__dict__["event"] == "http_request"
+    assert record.__dict__["path"] == "/health"
+    assert record.__dict__["httpStatus"] == 200
 
 
 def test_score_endpoint_accepts_form_encoded_preferences() -> None:
@@ -504,19 +507,19 @@ def test_score_endpoint_reuses_cached_response_for_identical_preferences() -> No
     call_count = 0
     original_builder = backend_main.build_score_response
 
-    def counted_builder(repository: StubClimateRepository, preferences: PreferenceInputs) -> dict[str, object]:
+    def counted_builder(repository: StubClimateRepository, preferences: PreferenceInputs) -> ScoreResponse:
         nonlocal call_count
         call_count += 1
         return original_builder(repository, preferences)
 
-    backend_main.build_score_response = counted_builder
+    backend_main.__dict__["build_score_response"] = counted_builder
     cached_client = TestClient(create_app(climate_repository=StubClimateRepository()))
 
     try:
         first_response = cached_client.post("/score", data=default_form_data())
         second_response = cached_client.post("/score", data=default_form_data())
     finally:
-        backend_main.build_score_response = original_builder
+        backend_main.__dict__["build_score_response"] = original_builder
 
     assert first_response.status_code == 200
     assert second_response.status_code == 200
@@ -527,18 +530,18 @@ def test_score_endpoint_uses_prewarmed_default_preferences_cache() -> None:
     call_count = 0
     original_builder = backend_main.build_score_response
 
-    def counted_builder(repository: StubClimateRepository, preferences: PreferenceInputs) -> dict[str, object]:
+    def counted_builder(repository: StubClimateRepository, preferences: PreferenceInputs) -> ScoreResponse:
         nonlocal call_count
         call_count += 1
         return original_builder(repository, preferences)
 
-    backend_main.build_score_response = counted_builder
+    backend_main.__dict__["build_score_response"] = counted_builder
 
     try:
         cached_client = TestClient(create_app(climate_repository=StubClimateRepository()))
         response = cached_client.post("/score", data=rendered_default_form_data())
     finally:
-        backend_main.build_score_response = original_builder
+        backend_main.__dict__["build_score_response"] = original_builder
 
     assert response.status_code == 200
     assert call_count == 1  # pre-warm only; the first default request should hit cache
@@ -548,12 +551,12 @@ def test_score_endpoint_evicts_oldest_cached_preferences_after_cache_limit() -> 
     call_count = 0
     original_builder = backend_main.build_score_response
 
-    def counted_builder(repository: StubClimateRepository, preferences: PreferenceInputs) -> dict[str, object]:
+    def counted_builder(repository: StubClimateRepository, preferences: PreferenceInputs) -> ScoreResponse:
         nonlocal call_count
         call_count += 1
         return original_builder(repository, preferences)
 
-    backend_main.build_score_response = counted_builder
+    backend_main.__dict__["build_score_response"] = counted_builder
     cached_client = TestClient(create_app(climate_repository=StubClimateRepository()))
     base_form = default_form_data()
 
@@ -568,7 +571,7 @@ def test_score_endpoint_evicts_oldest_cached_preferences_after_cache_limit() -> 
         repeated_first = cached_client.post("/score", data={**base_form, "dryness_preference": "0"})
         newest_repeat = cached_client.post("/score", data={**base_form, "dryness_preference": "16"})
     finally:
-        backend_main.build_score_response = original_builder
+        backend_main.__dict__["build_score_response"] = original_builder
 
     assert repeated_first.status_code == 200
     assert newest_repeat.status_code == 200

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -59,6 +59,10 @@ def default_query_params() -> dict[str, int | float]:
     }
 
 
+def rendered_default_form_data() -> dict[str, str]:
+    return {preference.name: str(preference.value) for preference in DEFAULT_PREFERENCES}
+
+
 class ManyCitiesRepository:
     def __init__(self) -> None:
         self._cells = tuple(
@@ -506,6 +510,27 @@ def test_score_endpoint_reuses_cached_response_for_identical_preferences() -> No
     assert first_response.status_code == 200
     assert second_response.status_code == 200
     assert call_count == 2  # 1 pre-warm (default prefs) + 1 first request (different prefs, cache miss)
+
+
+def test_score_endpoint_uses_prewarmed_default_preferences_cache() -> None:
+    call_count = 0
+    original_builder = backend_main.build_score_response
+
+    def counted_builder(repository: StubClimateRepository, preferences: PreferenceInputs) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        return original_builder(repository, preferences)
+
+    backend_main.build_score_response = counted_builder
+
+    try:
+        cached_client = TestClient(create_app(climate_repository=StubClimateRepository()))
+        response = cached_client.post("/score", data=rendered_default_form_data())
+    finally:
+        backend_main.build_score_response = original_builder
+
+    assert response.status_code == 200
+    assert call_count == 1  # pre-warm only; the first default request should hit cache
 
 
 def test_score_endpoint_evicts_oldest_cached_preferences_after_cache_limit() -> None:

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -1,4 +1,6 @@
 import logging
+import threading
+import time
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -271,13 +273,22 @@ def test_map_contract_does_not_depend_on_remote_basemap_assets() -> None:
 
 def test_probe_script_snaps_cache_keys_and_query_params_to_backend_grid() -> None:
     response = client.get("/static/map-probe.js")
+    core_response = client.get("/static/map-core.js")
 
     assert response.status_code == 200
+    assert core_response.status_code == 200
     assert "function snapProbeCoordinate" in response.text
     assert "probeGridDegrees" in response.text
     assert "const snapped = snapProbeCoordinate(lat, lon);" in response.text
     assert "const cacheKey = `${snapped.lat},${snapped.lon},${new URLSearchParams(prefs)}`;" in response.text
     assert "new URLSearchParams({ lat: snapped.lat, lon: snapped.lon, ...prefs });" in response.text
+    assert "const PROBE_HOVER_COOLDOWN_MS = 250;" in core_response.text
+    assert "let probeRequestToken = 0;" in core_response.text
+    assert "probeRequestToken += 1;" in response.text
+    assert "cancelProbeCooldown();" in response.text
+    assert "abortActiveProbe();" in response.text
+    assert "requestToken !== probeRequestToken" in response.text
+    assert "requestToken = ++probeRequestToken" in response.text
 
 
 def test_home_page_uses_gzip_when_requested() -> None:
@@ -562,6 +573,76 @@ def test_score_endpoint_evicts_oldest_cached_preferences_after_cache_limit() -> 
     assert repeated_first.status_code == 200
     assert newest_repeat.status_code == 200
     assert call_count == 19  # 1 pre-warm + 17 unique keys + 1 recompute after LRU eviction
+
+
+def test_score_response_cache_deduplicates_concurrent_identical_misses() -> None:
+    score_cache_class = backend_main.__dict__["_ScoreResponseCache"]
+    cache = score_cache_class(4)
+    key = (18, 30, 0, 30, 50)
+    build_started = threading.Event()
+    build_count = 0
+    results: list[dict[str, object]] = []
+
+    def build() -> dict[str, object]:
+        nonlocal build_count
+        build_count += 1
+        build_started.set()
+        time.sleep(0.05)
+        return {"scores": [], "heatmap": "cached"}
+
+    def worker() -> None:
+        results.append(cache.get_or_set(key, build))
+
+    threads = [threading.Thread(target=worker), threading.Thread(target=worker)]
+    threads[0].start()
+    assert build_started.wait(timeout=1)
+    threads[1].start()
+    for thread in threads:
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+
+    assert build_count == 1
+    assert results == [{"scores": [], "heatmap": "cached"}, {"scores": [], "heatmap": "cached"}]
+
+
+def test_score_response_cache_recovers_after_failing_inflight_build() -> None:
+    score_cache_class = backend_main.__dict__["_ScoreResponseCache"]
+    cache = score_cache_class(4)
+    key = (18, 30, 0, 30, 50)
+    build_started = threading.Event()
+    call_count = 0
+    failures: list[str] = []
+    successes: list[dict[str, object]] = []
+
+    def flaky_build() -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            build_started.set()
+            time.sleep(0.05)
+            msg = "boom"
+            raise RuntimeError(msg)
+        return {"scores": [], "heatmap": "recovered"}
+
+    def worker() -> None:
+        try:
+            successes.append(cache.get_or_set(key, flaky_build))
+        except RuntimeError as error:
+            failures.append(str(error))
+
+    threads = [threading.Thread(target=worker), threading.Thread(target=worker)]
+    threads[0].start()
+    assert build_started.wait(timeout=1)
+    threads[1].start()
+    for thread in threads:
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+
+    assert failures == ["boom"]
+    assert successes == [{"scores": [], "heatmap": "recovered"}]
+    assert call_count == 2
+    assert cache.get_or_set(key, flaky_build) == {"scores": [], "heatmap": "recovered"}
+    assert call_count == 2
 
 
 def test_dryness_preference_penalizes_rainier_cells() -> None:

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -509,7 +509,7 @@ def test_score_endpoint_reuses_cached_response_for_identical_preferences() -> No
 
     assert first_response.status_code == 200
     assert second_response.status_code == 200
-    assert call_count == 2  # 1 pre-warm (default prefs) + 1 first request (different prefs, cache miss)
+    assert call_count == 2  # 1 pre-warm + 1 miss for non-default form data
 
 
 def test_score_endpoint_uses_prewarmed_default_preferences_cache() -> None:
@@ -561,7 +561,7 @@ def test_score_endpoint_evicts_oldest_cached_preferences_after_cache_limit() -> 
 
     assert repeated_first.status_code == 200
     assert newest_repeat.status_code == 200
-    assert call_count == 19  # 1 pre-warm + 17 unique requests + repeated_first evicted by pre-warm occupying a slot
+    assert call_count == 19  # 1 pre-warm + 17 unique keys + 1 recompute after LRU eviction
 
 
 def test_dryness_preference_penalizes_rainier_cells() -> None:

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -14,19 +14,23 @@ def test_json_formatter_emits_railway_friendly_fields() -> None:
     formatter = _JSONFormatter()
     record = logging.LogRecord(
         name="backend.main",
-        level=logging.INFO,
+        level=logging.WARNING,
         pathname=__file__,
         lineno=1,
-        msg="http_request outcome=ok",
+        msg="http request finished",
         args=(),
         exc_info=None,
     )
+    record.event = "http_request"
+    record.httpStatus = 200
 
     payload = json.loads(formatter.format(record))
 
-    assert payload["level"] == "info"
+    assert payload["level"] == "warn"
     assert payload["logger"] == "backend.main"
-    assert payload["message"] == "http_request outcome=ok"
+    assert payload["message"] == "http request finished"
+    assert payload["event"] == "http_request"
+    assert payload["httpStatus"] == 200
     assert "timestamp" in payload
 
 

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -34,6 +34,25 @@ def test_json_formatter_emits_railway_friendly_fields() -> None:
     assert "timestamp" in payload
 
 
+def test_json_formatter_serializes_nested_extra_values() -> None:
+    formatter = _JSONFormatter()
+    record = logging.LogRecord(
+        name="backend.main",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="score request finished",
+        args=(),
+        exc_info=None,
+    )
+    record.event = "score_request"
+    record.metrics = {"durations": [1.2, 3], "cache": ("hit", True)}
+
+    payload = json.loads(formatter.format(record))
+
+    assert payload["metrics"] == {"durations": [1.2, 3], "cache": ["hit", True]}
+
+
 def test_configure_backend_logging_uses_plain_formatter_locally(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.delenv("RAILWAY_ENVIRONMENT", raising=False)
     monkeypatch.delenv("RAILWAY_SERVICE_NAME", raising=False)

--- a/tests/test_probe_frontend.py
+++ b/tests/test_probe_frontend.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def _run_probe_runtime_scenario(scenario: str) -> None:
+    root = Path(__file__).resolve().parents[1]
+    map_core = (root / "frontend" / "static" / "map-core.js").read_text(encoding="utf-8")
+    map_probe = (root / "frontend" / "static" / "map-probe.js").read_text(encoding="utf-8")
+    script = textwrap.dedent(
+        f"""
+        const vm = require("node:vm");
+
+        const eventHandlers = new Map();
+        const timers = new Map();
+        let nextTimerId = 1;
+        const pendingFetches = [];
+        const tooltipEl = {{ hidden: true, innerHTML: "", style: {{}}, getBoundingClientRect: () => ({{ width: 120, height: 40 }}) }};
+        const form = {{ id: "preferences" }};
+        const mapHandlers = new Map();
+        const mapStub = {{
+          on(eventName, layerOrHandler, handler) {{
+            const key = handler ? `${{eventName}}:${{layerOrHandler}}` : eventName;
+            mapHandlers.set(key, handler ?? layerOrHandler);
+          }},
+          getCanvas() {{
+            return {{ style: {{ cursor: "" }} }};
+          }},
+          getContainer() {{
+            return {{ getBoundingClientRect: () => ({{ left: 0, top: 0, right: 800, bottom: 600 }}) }};
+          }},
+          queryRenderedFeatures() {{
+            return [];
+          }},
+          getSource() {{
+            return null;
+          }},
+          project([lon, lat]) {{
+            return {{ x: lon, y: lat }};
+          }},
+        }};
+
+        globalThis.window = globalThis;
+        globalThis.setTimeout = (fn, ms) => {{
+          const id = nextTimerId++;
+          timers.set(id, {{ fn, ms }});
+          return id;
+        }};
+        globalThis.clearTimeout = (id) => {{
+          timers.delete(id);
+        }};
+        globalThis.requestAnimationFrame = () => 0;
+        globalThis.cancelAnimationFrame = () => {{}};
+        globalThis.fetch = (url, options = {{}}) => new Promise((resolve, reject) => {{
+          pendingFetches.push({{ url, options, resolve, reject }});
+        }});
+        globalThis.document = {{
+          readyState: "complete",
+          addEventListener(name, handler) {{
+            eventHandlers.set(name, handler);
+          }},
+          getElementById(id) {{
+            if (id === "map-probe-tooltip") return tooltipEl;
+            if (id === "preferences") return form;
+            return null;
+          }},
+        }};
+        globalThis.FormData = class FormData {{
+          constructor(_form) {{}}
+          entries() {{
+            return [
+              ["preferred_day_temperature", "22"],
+              ["summer_heat_limit", "30"],
+              ["winter_cold_limit", "5"],
+              ["dryness_preference", "60"],
+              ["sunshine_preference", "60"],
+            ][Symbol.iterator]();
+          }}
+        }};
+
+        vm.runInThisContext({map_core!r});
+        vm.runInThisContext({map_probe!r});
+        vm.runInThisContext(`
+          globalThis.__probeTest = {{
+            mapHandlers,
+            eventHandlers,
+            pendingFetches,
+            tooltip,
+            setMap(value) {{ map = value; }},
+            setMapLoaded(value) {{ mapLoaded = value; }},
+            pendingTimerCount(delay) {{
+              return [...timers.values()].filter((timer) => timer.ms === delay).length;
+            }},
+            runTimersByDelay(delay) {{
+              const due = [...timers.entries()].filter(([, timer]) => timer.ms === delay);
+              for (const [id, timer] of due) {{
+                timers.delete(id);
+                timer.fn();
+              }}
+            }},
+          }};
+        `);
+
+        async function flushMicrotasks() {{
+          await Promise.resolve();
+          await Promise.resolve();
+        }}
+
+        async function resolveFetch(index, payload) {{
+          const request = pendingFetches[index];
+          request.resolve({{
+            ok: true,
+            json: async () => payload,
+          }});
+          await flushMicrotasks();
+        }}
+
+        async function main() {{
+          const test = globalThis.__probeTest;
+          test.setMap(mapStub);
+          test.setMapLoaded(true);
+          {scenario}
+        }}
+
+        main().catch((error) => {{
+          console.error(error);
+          process.exit(1);
+        }});
+        """
+    )
+
+    result = subprocess.run(["node", "-e", script], cwd=root, capture_output=True, text=True, check=False)  # noqa: S603,S607
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_probe_runtime_ignores_inflight_layer_response_after_mouseleave() -> None:
+    _run_probe_runtime_scenario(
+        textwrap.dedent(
+            """
+            registerLayerProbeHandlers("marker", { cursor: "pointer", header: () => "Flag City" });
+            mapHandlers.get("mouseenter:marker")({
+              lngLat: { lat: 12, lng: 34 },
+              originalEvent: { clientX: 10, clientY: 20 },
+            });
+            if (pendingFetches.length !== 1) throw new Error(`expected 1 pending fetch, got ${pendingFetches.length}`);
+
+            mapHandlers.get("mouseleave:marker")();
+            await resolveFetch(0, { found: true, overall_score: 0.7, metrics: [] });
+
+            if (!tooltip.hidden) throw new Error("stale probe response re-showed the tooltip after mouseleave");
+            if (tooltip.innerHTML !== "") throw new Error("stale probe response rewrote tooltip content after mouseleave");
+            """
+        )
+    )
+
+
+def test_probe_runtime_cancels_queued_hover_probe_after_preference_change() -> None:
+    _run_probe_runtime_scenario(
+        textwrap.dedent(
+            """
+            scheduleHoverProbe({
+              point: { x: 1, y: 2 },
+              lngLat: { lat: 12, lng: 34 },
+              originalEvent: { clientX: 10, clientY: 20 },
+            });
+            __probeTest.runTimersByDelay(80);
+
+            eventHandlers.get("input")({
+              target: {
+                closest(selector) {
+                  return selector === "#preferences" ? {} : null;
+                },
+              },
+            });
+            __probeTest.runTimersByDelay(250);
+
+            if (pendingFetches.length !== 0) throw new Error(`expected queued hover probe to be cancelled, got ${pendingFetches.length} fetches`);
+            """
+        )
+    )
+
+
+def test_probe_runtime_keeps_new_timeout_when_older_request_finishes() -> None:
+    _run_probe_runtime_scenario(
+        textwrap.dedent(
+            """
+            fetchProbe(12, 34, 10, 20, null, { cooldownMs: 0, requestToken: ++probeRequestToken });
+            if (__probeTest.pendingTimerCount(5000) !== 1) throw new Error("expected first probe timeout");
+
+            fetchProbe(13, 35, 11, 21, null, { cooldownMs: 0, requestToken: ++probeRequestToken });
+            if (__probeTest.pendingTimerCount(5000) !== 1) throw new Error("expected one active timeout after replacing probe");
+
+            pendingFetches[0].reject(new Error("aborted"));
+            await flushMicrotasks();
+
+            if (__probeTest.pendingTimerCount(5000) !== 1) throw new Error("older probe cleanup cleared the newer timeout");
+            """
+        )
+    )
+
+
+def test_probe_runtime_hides_visible_tooltip_on_preference_change() -> None:
+    _run_probe_runtime_scenario(
+        textwrap.dedent(
+            """
+            tooltip.hidden = false;
+            tooltip.innerHTML = "stale";
+
+            eventHandlers.get("input")({
+              target: {
+                closest(selector) {
+                  return selector === "#preferences" ? {} : null;
+                },
+              },
+            });
+
+            if (!tooltip.hidden) throw new Error("preference change should hide stale tooltip");
+            """
+        )
+    )
+
+
+def test_probe_runtime_ignores_cached_hover_probe_after_reset() -> None:
+    _run_probe_runtime_scenario(
+        textwrap.dedent(
+            """
+            fetchProbe(12, 34, 10, 20, null, { cooldownMs: 0, requestToken: ++probeRequestToken });
+            await resolveFetch(0, { found: true, overall_score: 0.7, metrics: [] });
+
+            scheduleHoverProbe({
+              point: { x: 1, y: 2 },
+              lngLat: { lat: 12, lng: 34 },
+              originalEvent: { clientX: 10, clientY: 20 },
+            });
+            resetTransientMapUi();
+            __probeTest.runTimersByDelay(80);
+
+            if (!tooltip.hidden) throw new Error("reset should suppress cached hover tooltip reuse");
+            """
+        )
+    )

--- a/tests/test_score_service.py
+++ b/tests/test_score_service.py
@@ -54,15 +54,15 @@ def test_build_score_response_logs_step_timings(caplog: LogCaptureFixture) -> No
     assert caplog.records
     record = caplog.records[-1]
     assert record.message == "score request finished"
-    assert record.event == "score_request"
-    assert record.outcome == "ok"
-    assert record.total_ms >= 0
-    assert record.cells_ms >= 0
-    assert record.cities_ms >= 0
-    assert record.scoring_ms >= 0
-    assert record.normalize_ms >= 0
-    assert record.ranking_ms >= 0
-    assert record.heatmap_ms >= 0
+    assert record.__dict__["event"] == "score_request"
+    assert record.__dict__["outcome"] == "ok"
+    assert cast("float", record.__dict__["total_ms"]) >= 0
+    assert cast("float", record.__dict__["cells_ms"]) >= 0
+    assert cast("float", record.__dict__["cities_ms"]) >= 0
+    assert cast("float", record.__dict__["scoring_ms"]) >= 0
+    assert cast("float", record.__dict__["normalize_ms"]) >= 0
+    assert cast("float", record.__dict__["ranking_ms"]) >= 0
+    assert cast("float", record.__dict__["heatmap_ms"]) >= 0
 
 
 def test_build_score_response_returns_empty_payload_for_empty_matrix() -> None:

--- a/tests/test_score_service.py
+++ b/tests/test_score_service.py
@@ -51,14 +51,18 @@ def test_build_score_response_logs_step_timings(caplog: LogCaptureFixture) -> No
     assert response["scores"]
     assert "markers" not in response
     assert response["heatmap"].startswith("data:image/png;base64,")
-    assert "score_request outcome=ok" in caplog.text
-    assert "total_ms=" in caplog.text
-    assert "cells_ms=" in caplog.text
-    assert "cities_ms=" in caplog.text
-    assert "scoring_ms=" in caplog.text
-    assert "normalize_ms=" in caplog.text
-    assert "ranking_ms=" in caplog.text
-    assert "heatmap_ms=" in caplog.text
+    assert caplog.records
+    record = caplog.records[-1]
+    assert record.message == "score request finished"
+    assert record.event == "score_request"
+    assert record.outcome == "ok"
+    assert record.total_ms >= 0
+    assert record.cells_ms >= 0
+    assert record.cities_ms >= 0
+    assert record.scoring_ms >= 0
+    assert record.normalize_ms >= 0
+    assert record.ranking_ms >= 0
+    assert record.heatmap_ms >= 0
 
 
 def test_build_score_response_returns_empty_payload_for_empty_matrix() -> None:


### PR DESCRIPTION
## Summary
- reduce first-load and repeated `/score` latency by switching the page to shell-first HTMX bootstrap, prewarming the default score response, caching repeated score responses per worker, and reusing precomputed climate aggregates during scoring
- cut heatmap and probe overhead by shrinking the heatmap raster, moving the fixed land-mask dilation into cached projection setup, and throttling uncached free-map tooltip probes while canceling stale hover work safely
- standardize app logs around structured event fields for Railway ingestion, then extend runtime, concurrency, and README coverage so the cache, startup, tooltip, and observability behavior stays explicit

## Testing
- `uv run pytest`
- `uv run ruff check .`
