### PR TITLE
Reduce runtime RSS with probe row fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ Notes:
 
 - Default local URL: `http://127.0.0.1:8000`
 - Live reload is on by default.
-- If `data/climate.duckdb` exists, startup warms the climate matrix, city cache, and heatmap projection.
+- If `data/climate.duckdb` exists, startup warms the score-time climate aggregates, city cache, heatmap projection, and the lookup indexes that keep city ranking and probe snapping aligned.
+- `/probe` keeps using the same response contract, but it now fetches one monthly climate row on demand instead of keeping all monthly probe data resident.
 - When climate data is available, startup also precomputes and caches the default `/score` response; if that warmup hits a climate-data failure, startup logs it and continues.
 - The `/score` cache is per-worker, in-memory, bounded to `16` entries today, and collapses identical concurrent requests only within the same process.
 - If preload fails, startup logs the problem and requests fall back to the existing `503` path.
@@ -143,8 +144,9 @@ Railway-specific notes from the platform docs:
 
 - Pogodapp emits its own request logs instead of Uvicorn access logs, including on Railway.
 - Request logs are structured around `event=http_request` and include `outcome`, `method`, `path`, `query`, `httpStatus`, `srcIp`, `scheme`, `httpVersion`, `txBytes`, `responseTime`, and `host`.
-- Other structured events include `startup`, `startup_db`, `startup_bootstrap`, `startup_preload`, `startup_default_score`, `score_request`, and `probe_request`.
+- Other structured events include `startup`, `startup_db`, `startup_bootstrap`, `startup_preload`, `startup_default_score`, `score_request`, `probe_request`, and `runtime_memory`.
 - `score_request` logs also include `total_ms`, `cells_ms`, `cities_ms`, `scoring_ms`, `normalize_ms`, `ranking_ms`, `heatmap_ms`, `climate_cells`, `cities`, and `ranked_cities`.
+- `runtime_memory` logs snapshot Linux RSS plus cache component sizes before preload, after each preload step, and after the default `/score` warmup.
 - Railway JSON logs always include `level`, `message`, `timestamp`, `logger`, and any event-specific fields attached to the record.
 - Local runs use plain stdout logs; Railway uses single-line JSON on stdout for ingestion.
 

--- a/backend/climate_repository.py
+++ b/backend/climate_repository.py
@@ -41,20 +41,31 @@ TEMPERATURE_MIN_COLUMNS = tuple(f"tmin_{month}" for month in MONTH_NAMES)
 TEMPERATURE_MAX_COLUMNS = tuple(f"tmax_{month}" for month in MONTH_NAMES)
 PRECIPITATION_COLUMNS = tuple(f"prec_{month}" for month in MONTH_NAMES)
 CLOUD_COLUMNS = tuple(f"cloud_{month}" for month in MONTH_NAMES)
-SELECT_CLIMATE_MATRIX_QUERY = (
-    "SELECT\n    "
-    + ",\n    ".join(
-        (
-            "lat",
-            "lon",
-            *TEMPERATURE_MIN_COLUMNS,
-            *TEMPERATURE_MAX_COLUMNS,
-            *PRECIPITATION_COLUMNS,
-            *CLOUD_COLUMNS,
-        )
-    )
-    + "\nFROM climate_cells"
+TEMPERATURE_MAX_LIST = f"list_value({', '.join(TEMPERATURE_MAX_COLUMNS)})"
+PRECIPITATION_LIST = f"list_value({', '.join(PRECIPITATION_COLUMNS)})"
+CLOUD_LIST = f"list_value({', '.join(CLOUD_COLUMNS)})"
+AVERAGE_CLOUD_EXPR = f"list_avg({CLOUD_LIST})"
+AVERAGE_CLOUD_BANKERS_ROUND_EXPR = (
+    f"CAST(floor({AVERAGE_CLOUD_EXPR}) + CASE "
+    f"WHEN {AVERAGE_CLOUD_EXPR} - floor({AVERAGE_CLOUD_EXPR}) > 0.5 THEN 1 "
+    f"WHEN {AVERAGE_CLOUD_EXPR} - floor({AVERAGE_CLOUD_EXPR}) < 0.5 THEN 0 "
+    f"WHEN mod(CAST(floor({AVERAGE_CLOUD_EXPR}) AS BIGINT), 2) = 0 THEN 0 "
+    f"ELSE 1 END AS FLOAT)"
 )
+SELECT_CLIMATE_MATRIX_QUERY = (
+    f"SELECT\n"
+    f"    lat,\n"
+    f"    lon,\n"
+    f"    list_median({TEMPERATURE_MAX_LIST}) AS typical_highs_c,\n"
+    f"    greatest({', '.join(TEMPERATURE_MAX_COLUMNS)}) AS hottest_month_highs_c,\n"
+    f"    least({', '.join(TEMPERATURE_MIN_COLUMNS)}) AS coldest_month_lows_c,\n"
+    f"    list_median({PRECIPITATION_LIST}) AS median_precipitation_mm,\n"
+    f"    greatest({', '.join(PRECIPITATION_COLUMNS)}) AS wettest_precipitation_mm,\n"
+    f"    {AVERAGE_CLOUD_BANKERS_ROUND_EXPR} AS average_cloud_cover_pct,\n"
+    f"    CAST(greatest({', '.join(CLOUD_COLUMNS)}) AS FLOAT) AS gloomiest_cloud_cover_pct\n"
+    f"FROM climate_cells"
+)
+SELECT_PROBE_CLIMATE_CELL_QUERY = SELECT_CLIMATE_CELLS_QUERY + "\nWHERE round(lat, 4) = ? AND round(lon, 4) = ?"
 
 CITY_BASE_COLUMNS = ("name", "country_code", "lat", "lon", "cell_lat", "cell_lon")
 
@@ -73,11 +84,11 @@ class ClimateRepository(Protocol):
         """Return user-facing cities already mapped onto the dataset."""
 
     def get_climate_matrix(self) -> ClimateMatrix:
-        """Return compact climate arrays ready for vectorized scoring.
+        """Return compact score-time arrays ready for vectorized scoring.
 
-        DuckDB-backed repositories may omit `temperature_c` and return `None`
-        there; callers should rely on the min/max, precipitation, and cloud
-        arrays for hot-path work.
+        DuckDB-backed repositories may omit all monthly arrays and keep only
+        yearly scoring aggregates resident; callers that need monthly probe
+        data must use `get_probe_cell()`.
         """
 
     def get_indexed_cities(self) -> CityRankingCache:
@@ -85,6 +96,9 @@ class ClimateRepository(Protocol):
 
     def get_heatmap_projection(self) -> HeatmapProjection:
         """Return cached heatmap pixel coordinates aligned with the current climate matrix."""
+
+    def get_probe_cell(self, row_index: int) -> ClimateCell:
+        """Return one full climate row for probe rendering."""
 
 
 class StubClimateRepository:
@@ -110,6 +124,10 @@ class StubClimateRepository:
         """Return cached heatmap projection for the stub dataset."""
         climate_matrix = self.get_climate_matrix()
         return HeatmapProjection.from_coordinates(climate_matrix.latitudes, climate_matrix.longitudes)
+
+    def get_probe_cell(self, row_index: int) -> ClimateCell:
+        """Return one stub climate row by row index."""
+        return STUB_CLIMATE_CELLS[row_index]
 
 
 def build_default_climate_repository(database_path: Path) -> ClimateRepository:
@@ -169,10 +187,7 @@ class DuckDbClimateRepository:
         return self._cities
 
     def get_climate_matrix(self) -> ClimateMatrix:
-        """Load the scoring columns once into compact arrays for repeated scoring.
-
-        Monthly mean temperatures are omitted from the cached runtime matrix to
-        reduce RAM.
+        """Load the score-time yearly aggregates once into compact arrays.
 
         Raises:
             ClimateDataError: The database file is missing, unreadable, or does
@@ -185,10 +200,13 @@ class DuckDbClimateRepository:
             columns = self._fetch_numpy_columns(SELECT_CLIMATE_MATRIX_QUERY)
             latitudes = np.asarray(columns["lat"], dtype=FLOAT32_DTYPE)
             longitudes = np.asarray(columns["lon"], dtype=FLOAT32_DTYPE)
-            temperature_min_c = self._build_monthly_matrix(columns, TEMPERATURE_MIN_COLUMNS, dtype=FLOAT32_DTYPE)
-            temperature_max_c = self._build_monthly_matrix(columns, TEMPERATURE_MAX_COLUMNS, dtype=FLOAT32_DTYPE)
-            precipitation_mm = self._build_monthly_matrix(columns, PRECIPITATION_COLUMNS, dtype=FLOAT32_DTYPE)
-            cloud_cover_pct = self._build_monthly_matrix(columns, CLOUD_COLUMNS, dtype=UINT8_DTYPE)
+            typical_highs_c = np.asarray(columns["typical_highs_c"], dtype=FLOAT32_DTYPE)
+            hottest_month_highs_c = np.asarray(columns["hottest_month_highs_c"], dtype=FLOAT32_DTYPE)
+            coldest_month_lows_c = np.asarray(columns["coldest_month_lows_c"], dtype=FLOAT32_DTYPE)
+            median_precipitation_mm = np.asarray(columns["median_precipitation_mm"], dtype=FLOAT32_DTYPE)
+            wettest_precipitation_mm = np.asarray(columns["wettest_precipitation_mm"], dtype=FLOAT32_DTYPE)
+            average_cloud_cover_pct = np.asarray(columns["average_cloud_cover_pct"], dtype=FLOAT32_DTYPE)
+            gloomiest_cloud_cover_pct = np.asarray(columns["gloomiest_cloud_cover_pct"], dtype=FLOAT32_DTYPE)
         except (KeyError, TypeError, ValueError) as error:
             msg = f"Failed to map climate data from {self.database_path} into climate rows: {error}"
             raise ClimateDataError(msg) from error
@@ -197,10 +215,13 @@ class DuckDbClimateRepository:
             latitudes=latitudes,
             longitudes=longitudes,
             temperature_c=None,
-            temperature_min_c=temperature_min_c,
-            temperature_max_c=temperature_max_c,
-            precipitation_mm=precipitation_mm,
-            cloud_cover_pct=cloud_cover_pct,
+            typical_highs_c=typical_highs_c,
+            hottest_month_highs_c=hottest_month_highs_c,
+            coldest_month_lows_c=coldest_month_lows_c,
+            median_precipitation_mm=median_precipitation_mm,
+            wettest_precipitation_mm=wettest_precipitation_mm,
+            average_cloud_cover_pct=average_cloud_cover_pct,
+            gloomiest_cloud_cover_pct=gloomiest_cloud_cover_pct,
         )
         return self._climate_matrix
 
@@ -253,14 +274,83 @@ class DuckDbClimateRepository:
             return None
         return int(sorted_indexes[pos])
 
-    def _fetch_rows(self, query: str, *, table_name: str = "climate_cells") -> list[tuple[object, ...]]:
+    def get_probe_cell(self, row_index: int) -> ClimateCell:
+        """Fetch one full climate row on demand for `/probe`."""
+        climate_matrix = self.get_climate_matrix()
+        probe_lat = round(float(climate_matrix.latitudes[row_index]), 4)
+        probe_lon = round(float(climate_matrix.longitudes[row_index]), 4)
+        rows = self._fetch_rows(SELECT_PROBE_CLIMATE_CELL_QUERY, parameters=(probe_lat, probe_lon))
+        if not rows:
+            msg = f"Failed to read climate data from {self.database_path}: probe row not found for {probe_lat}, {probe_lon}"
+            raise ClimateDataError(msg)
+
+        try:
+            return self._row_to_climate_cell(rows[0])
+        except (TypeError, ValueError) as error:
+            msg = f"Failed to map climate data from {self.database_path} into climate rows: {error}"
+            raise ClimateDataError(msg) from error
+
+    def get_runtime_cache_stats(self) -> dict[str, float]:
+        """Return approximate resident cache sizes for preload logging."""
+        climate_matrix_mb = 0.0
+        if self._climate_matrix is not None:
+            climate_matrix_mb = round(self._climate_matrix_nbytes(self._climate_matrix) / (1024 * 1024), 1)
+
+        city_cache_mb = 0.0
+        if self._indexed_cities is not None:
+            city_cache_mb = round(
+                (
+                    self._indexed_cities.climate_indexes.nbytes
+                    + self._indexed_cities.latitude_radians.nbytes
+                    + self._indexed_cities.longitude_radians.nbytes
+                    + self._indexed_cities.cosine_latitudes.nbytes
+                )
+                / (1024 * 1024),
+                1,
+            )
+
+        probe_lookup_mb = 0.0
+        if self._sorted_climate_keys is not None and self._sorted_climate_indexes is not None:
+            probe_lookup_mb = round(
+                (self._sorted_climate_keys.nbytes + self._sorted_climate_indexes.nbytes) / (1024 * 1024),
+                1,
+            )
+
+        heatmap_projection_mb = 0.0
+        if self._heatmap_projection is not None:
+            heatmap_projection_mb = round(
+                (
+                    self._heatmap_projection.score_indexes.nbytes
+                    + self._heatmap_projection.xs.nbytes
+                    + self._heatmap_projection.ys.nbytes
+                    + self._heatmap_projection.land_mask.nbytes
+                )
+                / (1024 * 1024),
+                1,
+            )
+
+        return {
+            "climate_matrix_mb": climate_matrix_mb,
+            "city_cache_mb": city_cache_mb,
+            "probe_lookup_mb": probe_lookup_mb,
+            "heatmap_projection_mb": heatmap_projection_mb,
+            "runtime_cache_mb": round(climate_matrix_mb + city_cache_mb + probe_lookup_mb + heatmap_projection_mb, 1),
+        }
+
+    def _fetch_rows(
+        self,
+        query: str,
+        *,
+        table_name: str = "climate_cells",
+        parameters: tuple[object, ...] = (),
+    ) -> list[tuple[object, ...]]:
         if not self.database_path.exists():
             msg = f"Climate database file not found: {self.database_path}"
             raise ClimateDataError(msg)
 
         try:
             with duckdb.connect(str(self.database_path), read_only=True) as connection:
-                return connection.execute(query).fetchall()
+                return connection.execute(query, parameters).fetchall()
         except duckdb.Error as error:
             if table_name == "cities" and "Table with name cities does not exist" in str(error):
                 msg = (
@@ -395,3 +485,27 @@ class DuckDbClimateRepository:
         self._sorted_climate_indexes = np.argsort(climate_keys).astype(np.int32, copy=False)
         self._sorted_climate_keys = climate_keys[self._sorted_climate_indexes]
         return self._sorted_climate_keys, self._sorted_climate_indexes
+
+    def _climate_matrix_nbytes(self, climate_matrix: ClimateMatrix) -> int:
+        total = (
+            climate_matrix.latitudes.nbytes
+            + climate_matrix.longitudes.nbytes
+            + climate_matrix.typical_highs_c.nbytes
+            + climate_matrix.hottest_month_highs_c.nbytes
+            + climate_matrix.coldest_month_lows_c.nbytes
+            + climate_matrix.median_precipitation_mm.nbytes
+            + climate_matrix.wettest_precipitation_mm.nbytes
+            + climate_matrix.average_cloud_cover_pct.nbytes
+            + climate_matrix.gloomiest_cloud_cover_pct.nbytes
+        )
+        if climate_matrix.temperature_c is not None:
+            total += climate_matrix.temperature_c.nbytes
+        if climate_matrix.temperature_min_c is not None:
+            total += climate_matrix.temperature_min_c.nbytes
+        if climate_matrix.temperature_max_c is not None:
+            total += climate_matrix.temperature_max_c.nbytes
+        if climate_matrix.precipitation_mm is not None:
+            total += climate_matrix.precipitation_mm.nbytes
+        if climate_matrix.cloud_cover_pct is not None:
+            total += climate_matrix.cloud_cover_pct.nbytes
+        return total

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import mmap
 import threading
 from collections import OrderedDict
 from dataclasses import asdict
@@ -30,17 +31,16 @@ from backend.logging_config import configure_backend_logging
 from backend.runtime import resolve_climate_database_path
 from backend.score_service import ScoreResponse, build_score_response
 from backend.scoring import (
+    ClimateCell,
     PreferenceInputs,
     ProbeBreakdown,
-    score_matrix_row_breakdown,
+    score_climate_cell_breakdown,
 )
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from starlette.middleware.base import RequestResponseEndpoint
-
-    from backend.scoring import ClimateMatrix
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
 FRONTEND_DIR = ROOT_DIR / "frontend"
@@ -117,7 +117,34 @@ class _ScoreResponseCache:
 class _SupportsProbeRepository(Protocol):
     def probe_nearest_cell(self, lat: float, lon: float) -> int | None: ...
 
-    def get_climate_matrix(self) -> ClimateMatrix: ...
+    def get_probe_cell(self, row_index: int) -> ClimateCell: ...
+
+
+def _current_rss_mb() -> float | None:
+    statm_path = Path("/proc/self/statm")
+    if not statm_path.exists():
+        return None
+
+    try:
+        rss_pages = int(statm_path.read_text(encoding="utf-8").split()[1])
+        return round((rss_pages * mmap.PAGESIZE) / (1024 * 1024), 1)
+    except OSError, ValueError, IndexError:
+        return None
+
+
+def _log_runtime_memory(stage: str, repository: ClimateRepository) -> None:
+    extra: dict[str, object] = {
+        "event": "runtime_memory",
+        "stage": stage,
+        "repository": type(repository).__name__,
+    }
+    rss_mb = _current_rss_mb()
+    if rss_mb is not None:
+        extra["rss_mb"] = rss_mb
+    get_runtime_cache_stats = getattr(repository, "get_runtime_cache_stats", None)
+    if callable(get_runtime_cache_stats):
+        extra.update(get_runtime_cache_stats())
+    logger.info("runtime memory snapshot", extra=extra)
 
 
 class ProbeMetricResponse(BaseModel):
@@ -162,11 +189,15 @@ def preload_repository(repository: ClimateRepository) -> None:
         return
 
     try:
+        _log_runtime_memory("before_preload", repository)
         # Test doubles and fallback repositories may only implement the slower request path.
         repository.get_climate_matrix()
+        _log_runtime_memory("after_climate_matrix", repository)
         repository.get_indexed_cities()
+        _log_runtime_memory("after_indexed_cities", repository)
         if hasattr(repository, "get_heatmap_projection"):
             repository.get_heatmap_projection()
+            _log_runtime_memory("after_heatmap_projection", repository)
         logger.info(
             "repository preload finished",
             extra={"event": "startup_preload", "outcome": "ok", "repository": type(repository).__name__},
@@ -312,6 +343,7 @@ def create_app(
     try:
         default_prefs = PreferenceInputs(**{f.name: f.value for f in DEFAULT_PREFERENCES})
         score_cache.set(_score_cache_key(default_prefs), build_score_response(repository, default_prefs))
+        _log_runtime_memory("after_default_score_cache", repository)
         logger.info("startup default score cached", extra={"event": "startup_default_score", "outcome": "ok"})
     except ClimateDataError:
         logger.warning("startup default score skipped", extra={"event": "startup_default_score", "outcome": "skipped"})
@@ -365,14 +397,14 @@ def create_app(
             row_index = probe_repository.probe_nearest_cell(lat, lon)
             if row_index is None:
                 return ProbeResponse()
-            climate_matrix = probe_repository.get_climate_matrix()
+            climate_cell = probe_repository.get_probe_cell(row_index)
         except ClimateDataError as error:
             logger.exception(
                 "probe request failed",
                 extra={"event": "probe_request", "outcome": "error", "lat": lat, "lon": lon},
             )
             raise HTTPException(status_code=503, detail=str(error)) from error
-        breakdown = score_matrix_row_breakdown(climate_matrix, row_index, preferences)
+        breakdown = score_climate_cell_breakdown(climate_cell, preferences)
         return build_probe_response(breakdown)
 
     return app

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, TypedDict, cast
 
 import numpy as np
 from pydantic import BaseModel, Field, model_validator
@@ -91,15 +91,19 @@ class ClimateCell:
 
 @dataclass(frozen=True, slots=True)
 class ClimateMatrix:
-    """Compact climate features for vectorized scoring; monthly averages may be omitted."""
+    """Compact score-time features for vectorized scoring.
+
+    Monthly arrays are optional because the runtime can keep yearly aggregates
+    resident for `/score` while `/probe` works from a full `ClimateCell`.
+    """
 
     latitudes: NDArray[np.float32]
     longitudes: NDArray[np.float32]
     temperature_c: NDArray[np.float32] | None
-    temperature_min_c: NDArray[np.float32]
-    temperature_max_c: NDArray[np.float32]
-    precipitation_mm: NDArray[np.float32]
-    cloud_cover_pct: NDArray[np.uint8]
+    temperature_min_c: NDArray[np.float32] | None = None
+    temperature_max_c: NDArray[np.float32] | None = None
+    precipitation_mm: NDArray[np.float32] | None = None
+    cloud_cover_pct: NDArray[np.uint8] | None = None
     typical_highs_c: NDArray[np.float32] = field(default_factory=lambda: np.array([], dtype=np.float32))
     hottest_month_highs_c: NDArray[np.float32] = field(default_factory=lambda: np.array([], dtype=np.float32))
     coldest_month_lows_c: NDArray[np.float32] = field(default_factory=lambda: np.array([], dtype=np.float32))
@@ -112,67 +116,114 @@ class ClimateMatrix:
         """Reject malformed matrix shapes before they reach the scorer."""
         cell_count = self.latitudes.shape[0]
 
-        self._validate_base_shapes(cell_count)
-        self._ensure_derived_vector(
-            "typical_highs_c",
-            np.median(self.temperature_max_c, axis=1).astype(np.float32, copy=False),
-            cell_count,
-        )
-        self._ensure_derived_vector(
-            "hottest_month_highs_c",
-            np.max(self.temperature_max_c, axis=1).astype(np.float32, copy=False),
-            cell_count,
-        )
-        self._ensure_derived_vector(
-            "coldest_month_lows_c",
-            np.min(self.temperature_min_c, axis=1).astype(np.float32, copy=False),
-            cell_count,
-        )
-        self._ensure_derived_vector(
-            "median_precipitation_mm",
-            np.median(self.precipitation_mm, axis=1).astype(np.float32, copy=False),
-            cell_count,
-        )
-        self._ensure_derived_vector(
-            "wettest_precipitation_mm",
-            np.max(self.precipitation_mm, axis=1).astype(np.float32, copy=False),
-            cell_count,
-        )
-        self._ensure_derived_vector(
-            "average_cloud_cover_pct",
-            np.rint(np.mean(self.cloud_cover_pct.astype(np.float32), axis=1)).astype(np.float32, copy=False),
-            cell_count,
-        )
-        self._ensure_derived_vector(
-            "gloomiest_cloud_cover_pct",
-            np.max(self.cloud_cover_pct, axis=1).astype(np.float32, copy=False),
-            cell_count,
-        )
+        self._validate_coordinate_shapes(cell_count)
 
-    def _validate_base_shapes(self, cell_count: int) -> None:
+        if self._has_monthly_inputs():
+            self._validate_base_shapes(cell_count)
+            temperature_min_c = cast("NDArray[np.float32]", self.temperature_min_c)
+            temperature_max_c = cast("NDArray[np.float32]", self.temperature_max_c)
+            precipitation_mm = cast("NDArray[np.float32]", self.precipitation_mm)
+            cloud_cover_pct = cast("NDArray[np.uint8]", self.cloud_cover_pct)
+            self._ensure_derived_vector(
+                "typical_highs_c",
+                np.median(temperature_max_c, axis=1).astype(np.float32, copy=False),
+                cell_count,
+            )
+            self._ensure_derived_vector(
+                "hottest_month_highs_c",
+                np.max(temperature_max_c, axis=1).astype(np.float32, copy=False),
+                cell_count,
+            )
+            self._ensure_derived_vector(
+                "coldest_month_lows_c",
+                np.min(temperature_min_c, axis=1).astype(np.float32, copy=False),
+                cell_count,
+            )
+            self._ensure_derived_vector(
+                "median_precipitation_mm",
+                np.median(precipitation_mm, axis=1).astype(np.float32, copy=False),
+                cell_count,
+            )
+            self._ensure_derived_vector(
+                "wettest_precipitation_mm",
+                np.max(precipitation_mm, axis=1).astype(np.float32, copy=False),
+                cell_count,
+            )
+            self._ensure_derived_vector(
+                "average_cloud_cover_pct",
+                np.rint(np.mean(cloud_cover_pct.astype(np.float32), axis=1)).astype(np.float32, copy=False),
+                cell_count,
+            )
+            self._ensure_derived_vector(
+                "gloomiest_cloud_cover_pct",
+                np.max(cloud_cover_pct, axis=1).astype(np.float32, copy=False),
+                cell_count,
+            )
+            return
+
+        self._validate_derived_only_shapes(cell_count)
+
+    def _validate_coordinate_shapes(self, cell_count: int) -> None:
         if self.longitudes.shape != (cell_count,):
             msg = "longitudes must align with latitudes"
             raise ValueError(msg)
+
+    def _has_monthly_inputs(self) -> bool:
+        monthly_arrays = (
+            self.temperature_min_c,
+            self.temperature_max_c,
+            self.precipitation_mm,
+            self.cloud_cover_pct,
+        )
+        has_any = any(array is not None for array in monthly_arrays)
+        has_all = all(array is not None for array in monthly_arrays)
+        if has_any and not has_all:
+            msg = (
+                "temperature_min_c, temperature_max_c, precipitation_mm, and cloud_cover_pct must be provided together"
+            )
+            raise ValueError(msg)
+        return has_all
+
+    def _validate_base_shapes(self, cell_count: int) -> None:
+        temperature_min_c = cast("NDArray[np.float32]", self.temperature_min_c)
+        temperature_max_c = cast("NDArray[np.float32]", self.temperature_max_c)
+        precipitation_mm = cast("NDArray[np.float32]", self.precipitation_mm)
+        cloud_cover_pct = cast("NDArray[np.uint8]", self.cloud_cover_pct)
 
         if self.temperature_c is not None and self.temperature_c.shape != (cell_count, MONTHS_PER_YEAR):
             msg = "temperature_c must be shaped (cells, 12)"
             raise ValueError(msg)
 
-        if self.temperature_min_c.shape != (cell_count, MONTHS_PER_YEAR):
+        if temperature_min_c.shape != (cell_count, MONTHS_PER_YEAR):
             msg = "temperature_min_c must be shaped (cells, 12)"
             raise ValueError(msg)
 
-        if self.temperature_max_c.shape != (cell_count, MONTHS_PER_YEAR):
+        if temperature_max_c.shape != (cell_count, MONTHS_PER_YEAR):
             msg = "temperature_max_c must be shaped (cells, 12)"
             raise ValueError(msg)
 
-        if self.precipitation_mm.shape != (cell_count, MONTHS_PER_YEAR):
+        if precipitation_mm.shape != (cell_count, MONTHS_PER_YEAR):
             msg = "precipitation_mm must be shaped (cells, 12)"
             raise ValueError(msg)
 
-        if self.cloud_cover_pct.shape != (cell_count, MONTHS_PER_YEAR):
+        if cloud_cover_pct.shape != (cell_count, MONTHS_PER_YEAR):
             msg = "cloud_cover_pct must be shaped (cells, 12)"
             raise ValueError(msg)
+
+    def _validate_derived_only_shapes(self, cell_count: int) -> None:
+        for attribute in (
+            "typical_highs_c",
+            "hottest_month_highs_c",
+            "coldest_month_lows_c",
+            "median_precipitation_mm",
+            "wettest_precipitation_mm",
+            "average_cloud_cover_pct",
+            "gloomiest_cloud_cover_pct",
+        ):
+            current = getattr(self, attribute)
+            if current.shape != (cell_count,):
+                msg = f"{attribute} must align with latitudes"
+                raise ValueError(msg)
 
     def _ensure_derived_vector(self, attribute: str, derived: NDArray[np.float32], cell_count: int) -> None:
         current = getattr(self, attribute)
@@ -516,6 +567,15 @@ def score_matrix_row_breakdown(
     preferences: PreferenceInputs,
 ) -> ProbeBreakdown:
     """Build `/probe` metrics from min/max, rain, and cloud rows without cached mean temperatures."""
+    if (
+        climate_matrix.temperature_min_c is None
+        or climate_matrix.temperature_max_c is None
+        or climate_matrix.precipitation_mm is None
+        or climate_matrix.cloud_cover_pct is None
+    ):
+        msg = "score_matrix_row_breakdown requires monthly climate arrays"
+        raise ValueError(msg)
+
     typical_high_value = float(np.median(climate_matrix.temperature_max_c[row_index]))
     hottest_month_high_value = float(np.max(climate_matrix.temperature_max_c[row_index]))
     coldest_month_low_value = float(np.min(climate_matrix.temperature_min_c[row_index]))
@@ -593,6 +653,12 @@ def score_matrix_row_breakdown(
         ),
     )
     return ProbeBreakdown(overall_score=overall_score, metrics=metric_scores)
+
+
+def score_climate_cell_breakdown(cell: ClimateCell, preferences: PreferenceInputs) -> ProbeBreakdown:
+    """Build `/probe` metrics from one on-demand climate row."""
+    climate_matrix = ClimateMatrix.from_cells((cell,))
+    return score_matrix_row_breakdown(climate_matrix, 0, preferences)
 
 
 def score_preferences(preferences: PreferenceInputs) -> list[CellScorePoint]:

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -1,7 +1,7 @@
 import logging
 import threading
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 from fastapi.testclient import TestClient
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
     from _pytest.monkeypatch import MonkeyPatch
 
+    from backend.climate_repository import ClimateRepository
     from backend.score_service import ScoreResponse
 
 
@@ -795,7 +796,7 @@ def test_probe_endpoint_rejects_typical_day_below_winter_limit() -> None:
 
 
 def test_score_endpoint_returns_all_available_cities_when_under_continent_reserve() -> None:
-    many_cities_client = TestClient(create_app(climate_repository=ManyCitiesRepository()))
+    many_cities_client = TestClient(create_app(climate_repository=cast("ClimateRepository", ManyCitiesRepository())))
 
     response = many_cities_client.post(
         "/score",
@@ -814,14 +815,11 @@ def test_score_endpoint_returns_all_available_cities_when_under_continent_reserv
 
 def test_probe_endpoint_returns_scored_breakdown_for_a_valid_cell() -> None:
     class ProbeRepository(StubClimateRepository):
-        def __init__(self) -> None:
-            self._matrix = ClimateMatrix.from_cells(self.list_cells())
-
-        def get_climate_matrix(self) -> ClimateMatrix:
-            return self._matrix
-
         def probe_nearest_cell(self, lat: float, lon: float) -> int | None:
             return 0
+
+        def get_probe_cell(self, row_index: int) -> ClimateCell:
+            return self.list_cells()[row_index]
 
     probe_client = TestClient(create_app(climate_repository=ProbeRepository()))
 
@@ -840,6 +838,32 @@ def test_probe_endpoint_returns_scored_breakdown_for_a_valid_cell() -> None:
     assert all(set(metric) == {"key", "label", "value", "display_value", "score"} for metric in payload["metrics"])
 
 
+def test_probe_endpoint_uses_probe_cell_without_loading_resident_matrix() -> None:
+    class ProbeOnlyRepository(StubClimateRepository):
+        def __init__(self) -> None:
+            self.matrix_calls = 0
+
+        def probe_nearest_cell(self, lat: float, lon: float) -> int | None:
+            return 0
+
+        def get_climate_matrix(self) -> ClimateMatrix:
+            self.matrix_calls += 1
+            return super().get_climate_matrix()
+
+        def get_probe_cell(self, row_index: int) -> ClimateCell:
+            return self.list_cells()[row_index]
+
+    repository = ProbeOnlyRepository()
+    probe_client = TestClient(create_app(climate_repository=cast("ClimateRepository", repository)))
+    matrix_calls_after_startup = repository.matrix_calls
+
+    response = probe_client.get("/probe", params=default_query_params())
+
+    assert response.status_code == 200
+    assert response.json()["found"] is True
+    assert repository.matrix_calls == matrix_calls_after_startup
+
+
 def test_probe_endpoint_returns_empty_payload_when_repository_has_no_probe_support() -> None:
     probe_client = TestClient(create_app(climate_repository=StubClimateRepository()))
 
@@ -854,12 +878,6 @@ def test_probe_endpoint_returns_empty_payload_when_repository_has_no_probe_suppo
 
 def test_probe_endpoint_returns_empty_payload_when_no_cell_is_found() -> None:
     class MissingProbeRepository(StubClimateRepository):
-        def __init__(self) -> None:
-            self._matrix = ClimateMatrix.from_cells(self.list_cells())
-
-        def get_climate_matrix(self) -> ClimateMatrix:
-            return self._matrix
-
         def probe_nearest_cell(self, lat: float, lon: float) -> int | None:
             return None
 
@@ -879,7 +897,7 @@ def test_probe_endpoint_returns_503_for_repository_failures() -> None:
         def probe_nearest_cell(self, lat: float, lon: float) -> int | None:
             return 0
 
-        def get_climate_matrix(self) -> ClimateMatrix:
+        def get_probe_cell(self, row_index: int) -> ClimateCell:
             msg = "Climate database file not found: data/climate.duckdb"
             raise ClimateDataError(msg)
 
@@ -943,3 +961,54 @@ def test_build_probe_response_preserves_metric_order_and_fields() -> None:
     assert response.found is True
     assert [metric.key for metric in response.metrics] == ["temp", "high", "low", "rain", "sun"]
     assert [metric.label for metric in response.metrics] == ["temp", "high", "low", "rain", "sun"]
+
+
+def test_preload_logs_runtime_memory_snapshots(monkeypatch: MonkeyPatch) -> None:
+    class InstrumentedRepository:
+        def get_climate_matrix(self) -> ClimateMatrix:
+            return ClimateMatrix.from_cells((StubClimateRepository().list_cells()[0],))
+
+        def get_indexed_cities(self) -> CityRankingCache:
+            return CityRankingCache.from_cities((), np.array([], dtype=np.int32))
+
+        def get_heatmap_projection(self) -> HeatmapProjection:
+            return HeatmapProjection.from_coordinates(np.array([], dtype=np.float32), np.array([], dtype=np.float32))
+
+        def list_cells(self) -> tuple[ClimateCell, ...]:
+            return ()
+
+        def list_cities(self) -> tuple[CityCandidate, ...]:
+            return ()
+
+        def get_runtime_cache_stats(self) -> dict[str, float]:
+            return {"runtime_cache_mb": 12.3}
+
+    runtime_stages: list[str] = []
+
+    def capture_runtime_memory(stage: str, repository: ClimateRepository) -> None:
+        runtime_stages.append(stage)
+
+    monkeypatch.setattr(backend_main, "_log_runtime_memory", capture_runtime_memory)
+
+    create_app(climate_repository=cast("ClimateRepository", InstrumentedRepository()))
+
+    assert runtime_stages == [
+        "before_preload",
+        "after_climate_matrix",
+        "after_indexed_cities",
+        "after_heatmap_projection",
+        "after_default_score_cache",
+    ]
+
+
+def test_current_rss_mb_returns_none_when_proc_statm_is_unavailable(monkeypatch: MonkeyPatch) -> None:
+    class MissingStatmPath:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+        def exists(self) -> bool:
+            return False
+
+    monkeypatch.setattr(backend_main, "Path", MissingStatmPath)
+
+    assert backend_main._current_rss_mb() is None  # noqa: SLF001

--- a/tests/test_climate_repository.py
+++ b/tests/test_climate_repository.py
@@ -124,18 +124,26 @@ def test_duckdb_climate_repository_loads_compact_matrix_with_expected_order_and_
     matrix = DuckDbClimateRepository(database_path).get_climate_matrix()
 
     assert matrix.temperature_c is None
+    assert matrix.temperature_min_c is None
+    assert matrix.temperature_max_c is None
+    assert matrix.precipitation_mm is None
+    assert matrix.cloud_cover_pct is None
     assert matrix.latitudes.dtype == np.float32
     assert matrix.longitudes.dtype == np.float32
-    assert matrix.temperature_min_c.dtype == np.float32
-    assert matrix.temperature_max_c.dtype == np.float32
-    assert matrix.precipitation_mm.dtype == np.float32
-    assert matrix.cloud_cover_pct.dtype == np.uint8
-    assert matrix.temperature_min_c.tolist() == [[-1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]]
-    assert matrix.temperature_max_c.tolist() == [[3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0]]
-    assert matrix.precipitation_mm.tolist() == [
-        [13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0]
-    ]
-    assert matrix.cloud_cover_pct.tolist() == [[25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36]]
+    assert matrix.typical_highs_c.dtype == np.float32
+    assert matrix.hottest_month_highs_c.dtype == np.float32
+    assert matrix.coldest_month_lows_c.dtype == np.float32
+    assert matrix.median_precipitation_mm.dtype == np.float32
+    assert matrix.wettest_precipitation_mm.dtype == np.float32
+    assert matrix.average_cloud_cover_pct.dtype == np.float32
+    assert matrix.gloomiest_cloud_cover_pct.dtype == np.float32
+    assert matrix.typical_highs_c.tolist() == [8.5]
+    assert matrix.hottest_month_highs_c.tolist() == [14.0]
+    assert matrix.coldest_month_lows_c.tolist() == [-1.0]
+    assert matrix.median_precipitation_mm.tolist() == [18.5]
+    assert matrix.wettest_precipitation_mm.tolist() == [24.0]
+    assert matrix.average_cloud_cover_pct.tolist() == [30.0]
+    assert matrix.gloomiest_cloud_cover_pct.tolist() == [36.0]
 
 
 def test_duckdb_climate_repository_raises_clear_error_for_compact_matrix_schema_mismatch(tmp_path: Path) -> None:
@@ -316,6 +324,41 @@ def test_duckdb_climate_repository_probe_nearest_cell_returns_none_for_unmapped_
     repository = DuckDbClimateRepository(database_path)
 
     assert repository.probe_nearest_cell(0.0, 0.0) is None
+
+
+def test_duckdb_climate_repository_get_probe_cell_fetches_monthly_row_on_demand(tmp_path: Path) -> None:
+    database_path = tmp_path / "climate.duckdb"
+    with duckdb.connect(str(database_path)) as connection:
+        connection.execute(
+            """
+            CREATE TABLE climate_cells AS
+            SELECT
+                10.5 AS lat,
+                20.5 AS lon,
+                1.0 AS t_jan, 2.0 AS t_feb, 3.0 AS t_mar, 4.0 AS t_apr, 5.0 AS t_may, 6.0 AS t_jun,
+                7.0 AS t_jul, 8.0 AS t_aug, 9.0 AS t_sep, 10.0 AS t_oct, 11.0 AS t_nov, 12.0 AS t_dec,
+                -1.0 AS tmin_jan, 0.0 AS tmin_feb, 1.0 AS tmin_mar, 2.0 AS tmin_apr, 3.0 AS tmin_may, 4.0 AS tmin_jun,
+                5.0 AS tmin_jul, 6.0 AS tmin_aug, 7.0 AS tmin_sep, 8.0 AS tmin_oct, 9.0 AS tmin_nov, 10.0 AS tmin_dec,
+                3.0 AS tmax_jan, 4.0 AS tmax_feb, 5.0 AS tmax_mar, 6.0 AS tmax_apr, 7.0 AS tmax_may, 8.0 AS tmax_jun,
+                9.0 AS tmax_jul, 10.0 AS tmax_aug, 11.0 AS tmax_sep, 12.0 AS tmax_oct, 13.0 AS tmax_nov, 14.0 AS tmax_dec,
+                13.0 AS prec_jan, 14.0 AS prec_feb, 15.0 AS prec_mar, 16.0 AS prec_apr, 17.0 AS prec_may, 18.0 AS prec_jun,
+                19.0 AS prec_jul, 20.0 AS prec_aug, 21.0 AS prec_sep, 22.0 AS prec_oct, 23.0 AS prec_nov, 24.0 AS prec_dec,
+                25 AS cloud_jan, 26 AS cloud_feb, 27 AS cloud_mar, 28 AS cloud_apr, 29 AS cloud_may, 30 AS cloud_jun,
+                31 AS cloud_jul, 32 AS cloud_aug, 33 AS cloud_sep, 34 AS cloud_oct, 35 AS cloud_nov, 36 AS cloud_dec
+            """
+        )
+
+    repository = DuckDbClimateRepository(database_path)
+
+    assert repository.get_probe_cell(0) == ClimateCell(
+        lat=10.5,
+        lon=20.5,
+        temperature_c=(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0),
+        temperature_min_c=(-1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0),
+        temperature_max_c=(3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0),
+        precipitation_mm=(13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0),
+        cloud_cover_pct=(25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36),
+    )
 
 
 def test_app_can_use_an_injected_climate_repository() -> None:

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -279,6 +279,48 @@ def test_vectorized_scoring_matches_scalar_scoring_for_extreme_inputs() -> None:
     assert np.allclose(vectorized_scores, scalar_scores)
 
 
+def test_vectorized_scoring_matches_full_matrix_when_only_derived_vectors_are_resident() -> None:
+    full_matrix = ClimateMatrix.from_cells(STUB_CLIMATE_CELLS)
+    derived_only_matrix = ClimateMatrix(
+        latitudes=full_matrix.latitudes,
+        longitudes=full_matrix.longitudes,
+        temperature_c=None,
+        typical_highs_c=full_matrix.typical_highs_c,
+        hottest_month_highs_c=full_matrix.hottest_month_highs_c,
+        coldest_month_lows_c=full_matrix.coldest_month_lows_c,
+        median_precipitation_mm=full_matrix.median_precipitation_mm,
+        wettest_precipitation_mm=full_matrix.wettest_precipitation_mm,
+        average_cloud_cover_pct=full_matrix.average_cloud_cover_pct,
+        gloomiest_cloud_cover_pct=full_matrix.gloomiest_cloud_cover_pct,
+    )
+    preferences = make_preferences(summer_heat_limit=28, winter_cold_limit=8)
+
+    assert np.allclose(
+        score_climate_matrix(derived_only_matrix, preferences),
+        score_climate_matrix(full_matrix, preferences),
+    )
+
+
+def test_climate_matrix_rejects_partially_populated_monthly_arrays() -> None:
+    with pytest.raises(ValueError, match="must be provided together"):
+        ClimateMatrix(
+            latitudes=np.array([0.0], dtype=np.float32),
+            longitudes=np.array([0.0], dtype=np.float32),
+            temperature_c=None,
+            temperature_min_c=np.array([[10.0] * 12], dtype=np.float32),
+            temperature_max_c=None,
+            precipitation_mm=None,
+            cloud_cover_pct=None,
+            typical_highs_c=np.array([20.0], dtype=np.float32),
+            hottest_month_highs_c=np.array([22.0], dtype=np.float32),
+            coldest_month_lows_c=np.array([8.0], dtype=np.float32),
+            median_precipitation_mm=np.array([15.0], dtype=np.float32),
+            wettest_precipitation_mm=np.array([30.0], dtype=np.float32),
+            average_cloud_cover_pct=np.array([20.0], dtype=np.float32),
+            gloomiest_cloud_cover_pct=np.array([30.0], dtype=np.float32),
+        )
+
+
 def test_normalize_score_array_scales_best_match_to_one() -> None:
     normalized = normalize_score_array(np.array([0.25, 0.5, 0.125], dtype=np.float32))
 
@@ -312,3 +354,22 @@ def test_score_matrix_row_breakdown_works_without_cached_average_temperatures() 
 
     assert isinstance(breakdown, ProbeBreakdown)
     assert 0 <= breakdown.overall_score <= 1
+
+
+def test_score_matrix_row_breakdown_rejects_aggregate_only_matrix() -> None:
+    full_matrix = ClimateMatrix.from_cells((STUB_CLIMATE_CELLS[0],))
+    derived_only_matrix = ClimateMatrix(
+        latitudes=full_matrix.latitudes,
+        longitudes=full_matrix.longitudes,
+        temperature_c=None,
+        typical_highs_c=full_matrix.typical_highs_c,
+        hottest_month_highs_c=full_matrix.hottest_month_highs_c,
+        coldest_month_lows_c=full_matrix.coldest_month_lows_c,
+        median_precipitation_mm=full_matrix.median_precipitation_mm,
+        wettest_precipitation_mm=full_matrix.wettest_precipitation_mm,
+        average_cloud_cover_pct=full_matrix.average_cloud_cover_pct,
+        gloomiest_cloud_cover_pct=full_matrix.gloomiest_cloud_cover_pct,
+    )
+
+    with pytest.raises(ValueError, match="requires monthly climate arrays"):
+        score_matrix_row_breakdown(derived_only_matrix, 0, make_preferences())


### PR DESCRIPTION
## Summary
- keep the resident DuckDB runtime cache score-oriented by storing only yearly scoring aggregates plus lookup/projection indexes
- move `/probe` onto on-demand full-row fetches so tooltip support no longer forces all monthly climate arrays to stay resident
- add runtime memory snapshots and regression coverage for the new score/probe split, preload telemetry, and guardrail behavior

Closes #64 

## Testing
- `uv run ruff check backend tests`
- `uv run ty check backend tests`
- `uv run pytest`
