### PR TITLE
Reduce /score request churn and unblock route handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It is not a weather app. It scores long-term climate normals against a few user 
 - `GET /` renders the page.
 - `GET /` renders the shell only; the first results arrive through an automatic HTMX `load` `POST /score` using the backend default preferences.
 - `POST /score` accepts `preferred_day_temperature`, `summer_heat_limit`, `winter_cold_limit`, `dryness_preference`, and `sunshine_preference` as form fields and returns JSON.
+- After the initial page-load score, HTMX re-submits the form on settled control `change` events with a `500ms` delay, so quick slider edits collapse into one `/score` request instead of fan-out bursts.
 - The response shape is `{"scores": [{"name", "continent", "country_code", "flag", "score", "lat", "lon", "probe_lat", "probe_lon"}, ...], "heatmap": "data:image/png;base64,..."}`.
 - Empty or all-zero results return `{"scores": [], "heatmap": ""}`.
 - `/score` is rate-limited to `30/minute` per client and returns `429` when that limit is exceeded.
@@ -38,7 +39,7 @@ It is not a weather app. It scores long-term climate normals against a few user 
 - `/probe` returns `{"found": false, "overall_score": 0.0, "metrics": []}` for ocean points, unmapped cells, or repositories without probe support.
 - FastAPI handles HTTP and validation.
 - Scoring, ranking, and heatmap rendering stay out of the route layer.
-- `frontend/static/map.js` only renders. HTMX submits the form and hands the response to the map code.
+- `frontend/static/map.js` only renders. HTMX submits the form, shows a brief `Calculating...` status in the controls panel, and hands the JSON response to the map code.
 - Tooltip probes snap hover points to the climate grid and cache results by snapped cell plus current preferences.
 
 ## Data

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, Field, ValidationError
 from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
+from starlette.concurrency import run_in_threadpool
 
 from backend.cities import GRID_DEGREES
 from backend.climate_repository import (
@@ -228,6 +229,21 @@ def _score_response_from_cache_or_repository(
     return score_cache.get_or_set(cache_key, lambda: build_score_response(repository, preferences))
 
 
+def _build_probe_response_from_repository(
+    repository: _SupportsProbeRepository,
+    lat: float,
+    lon: float,
+    preferences: PreferenceInputs,
+) -> ProbeResponse:
+    row_index = repository.probe_nearest_cell(lat, lon)
+    if row_index is None:
+        return ProbeResponse()
+
+    climate_cell = repository.get_probe_cell(row_index)
+    breakdown = score_climate_cell_breakdown(climate_cell, preferences)
+    return build_probe_response(breakdown)
+
+
 def probe_preferences_dependency(
     preferred_day_temperature: Annotated[int, Query(ge=5, le=35)],
     summer_heat_limit: Annotated[int, Query(ge=18, le=42)],
@@ -366,7 +382,9 @@ def create_app(
     @limiter.limit("30/minute")
     async def score(request: Request, preferences: Annotated[PreferenceInputs, Form()]) -> ScoreResponse:
         try:
-            return _score_response_from_cache_or_repository(score_cache, repository, preferences)
+            return await run_in_threadpool(
+                _score_response_from_cache_or_repository, score_cache, repository, preferences
+            )
         except ClimateDataError as error:
             logger.exception(
                 "score request failed",
@@ -394,18 +412,15 @@ def create_app(
             return ProbeResponse()
         probe_repository = cast("_SupportsProbeRepository", repository)
         try:
-            row_index = probe_repository.probe_nearest_cell(lat, lon)
-            if row_index is None:
-                return ProbeResponse()
-            climate_cell = probe_repository.get_probe_cell(row_index)
+            return await run_in_threadpool(
+                _build_probe_response_from_repository, probe_repository, lat, lon, preferences
+            )
         except ClimateDataError as error:
             logger.exception(
                 "probe request failed",
                 extra={"event": "probe_request", "outcome": "error", "lat": lat, "lon": lon},
             )
             raise HTTPException(status_code=503, detail=str(error)) from error
-        breakdown = score_climate_cell_breakdown(climate_cell, preferences)
-        return build_probe_response(breakdown)
 
     return app
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import mmap
 import threading
@@ -353,6 +354,7 @@ def create_app(
     app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
     repository = climate_repository or build_default_climate_repository(resolve_climate_database_path())
     score_cache = _ScoreResponseCache(SCORE_CACHE_SIZE)
+    score_request_semaphore = asyncio.Semaphore(1)
     preload_repository(repository)
 
     # Pre-warm default scores so the page-load HTMX POST hits cache instead of paying the cold path.
@@ -382,9 +384,10 @@ def create_app(
     @limiter.limit("30/minute")
     async def score(request: Request, preferences: Annotated[PreferenceInputs, Form()]) -> ScoreResponse:
         try:
-            return await run_in_threadpool(
-                _score_response_from_cache_or_repository, score_cache, repository, preferences
-            )
+            async with score_request_semaphore:
+                return await run_in_threadpool(
+                    _score_response_from_cache_or_repository, score_cache, repository, preferences
+                )
         except ClimateDataError as error:
             logger.exception(
                 "score request failed",

--- a/backend/main.py
+++ b/backend/main.py
@@ -354,6 +354,7 @@ def create_app(
     app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
     repository = climate_repository or build_default_climate_repository(resolve_climate_database_path())
     score_cache = _ScoreResponseCache(SCORE_CACHE_SIZE)
+    # Serialize /score work per worker so repeated slider changes do not pile up CPU-bound builds.
     score_request_semaphore = asyncio.Semaphore(1)
     preload_repository(repository)
 

--- a/frontend/static/app.js
+++ b/frontend/static/app.js
@@ -83,8 +83,7 @@ function bindScoreHandoff(form) {
     setLoading(true);
   });
 
-  // Successful `#preferences` submissions return the raw `/score` JSON payload,
-  // which the split map scripts consume through `window.renderScores`.
+  // HTMX returns raw /score JSON here; hand it straight to the map renderer.
   document.body.addEventListener("htmx:afterRequest", (event) => {
     if (event.detail.elt !== form) return;
     setLoading(false);

--- a/frontend/static/app.js
+++ b/frontend/static/app.js
@@ -71,10 +71,24 @@ function bindPreferenceControls(form) {
 }
 
 function bindScoreHandoff(form) {
+  const loadingIndicator = document.getElementById("score-loading-indicator");
+
+  const setLoading = (isLoading) => {
+    if (!loadingIndicator) return;
+    loadingIndicator.hidden = !isLoading;
+  };
+
+  document.body.addEventListener("htmx:beforeRequest", (event) => {
+    if (event.detail.elt !== form) return;
+    setLoading(true);
+  });
+
   // Successful `#preferences` submissions return the raw `/score` JSON payload,
   // which the split map scripts consume through `window.renderScores`.
   document.body.addEventListener("htmx:afterRequest", (event) => {
-    if (event.detail.elt !== form || event.detail.xhr.status !== 200) return;
+    if (event.detail.elt !== form) return;
+    setLoading(false);
+    if (event.detail.xhr.status !== 200) return;
     window.renderScores(JSON.parse(event.detail.xhr.responseText));
   });
 }

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -139,12 +139,48 @@ ul {
   grid-template-rows: auto minmax(0, 1fr);
 }
 
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
 .app-panel h2 {
   font-size: 0.9rem;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: #666666;
+}
+
+.score-loading-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #8aaeff;
+}
+
+.score-loading-indicator[hidden] {
+  display: none;
+}
+
+.score-loading-indicator__spinner {
+  width: 0.75rem;
+  height: 0.75rem;
+  border: 1px solid #2f3f63;
+  border-top-color: #4a9eff;
+  border-radius: 999px;
+  animation: score-loading-spin 0.8s linear infinite;
+}
+
+@keyframes score-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 #preferences {

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -26,7 +26,13 @@
       </header>
 
       <section class="app-panel controls-panel" aria-label="Controls area">
-        <h2>Controls</h2>
+        <div class="panel-header">
+          <h2>Controls</h2>
+          <div id="score-loading-indicator" class="score-loading-indicator" role="status" aria-live="polite" hidden>
+            <span class="score-loading-indicator__spinner" aria-hidden="true"></span>
+            <span>Calculating...</span>
+          </div>
+        </div>
         <form
           id="preferences"
           hx-post="/score"

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -30,7 +30,7 @@
         <form
           id="preferences"
           hx-post="/score"
-          hx-trigger="load, input changed delay:300ms"
+          hx-trigger="load, change"
           hx-sync="this:replace"
           hx-swap="none"
           hx-request='{"timeout": 30000}'

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -30,7 +30,7 @@
         <form
           id="preferences"
           hx-post="/score"
-          hx-trigger="load, change"
+          hx-trigger="load, change delay:500ms"
           hx-sync="this:replace"
           hx-swap="none"
           hx-request='{"timeout": 30000}'

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import threading
 import time
 from typing import TYPE_CHECKING, cast
 
+import httpx
 import numpy as np
+import pytest
 from fastapi.testclient import TestClient
 
 from backend.cities import GRID_DEGREES, CityCandidate, CityRankingCache, continent_of
@@ -71,6 +74,17 @@ def default_query_params() -> dict[str, int | float]:
 
 def rendered_default_form_data() -> dict[str, str]:
     return {preference.name: str(preference.value) for preference in DEFAULT_PREFERENCES}
+
+
+async def wait_for_thread_event(event: threading.Event, max_wait_seconds: float = 1.0) -> None:
+    deadline = time.perf_counter() + max_wait_seconds
+    while time.perf_counter() < deadline:
+        if event.is_set():
+            return
+        await asyncio.sleep(0.01)
+
+    msg = "thread event was not set before timeout"
+    raise AssertionError(msg)
 
 
 class ManyCitiesRepository:
@@ -502,6 +516,103 @@ def test_score_endpoint_offloads_scoring_to_threadpool(monkeypatch: MonkeyPatch)
     assert response.status_code == 200
     assert len(calls) == 1
     assert getattr(calls[0][0], "__name__", "") == "_score_response_from_cache_or_repository"
+
+
+@pytest.mark.anyio
+async def test_score_endpoint_serializes_concurrent_requests_per_worker() -> None:
+    entered = threading.Event()
+    release_first = threading.Event()
+    second_entered = threading.Event()
+    call_count = 0
+    lock = threading.Lock()
+    original_builder = backend_main.__dict__["_score_response_from_cache_or_repository"]
+    app = create_app(climate_repository=StubClimateRepository())
+
+    def slow_builder(*args: object) -> ScoreResponse:
+        nonlocal call_count
+        with lock:
+            call_count += 1
+            current_call = call_count
+
+        if current_call == 1:
+            entered.set()
+            assert release_first.wait(timeout=1)
+        else:
+            second_entered.set()
+
+        return {"scores": [], "heatmap": ""}
+
+    backend_main.__dict__["_score_response_from_cache_or_repository"] = slow_builder
+
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+            first_request = asyncio.create_task(async_client.post("/score", data=default_form_data()))
+            await wait_for_thread_event(entered)
+
+            second_request = asyncio.create_task(async_client.post("/score", data=default_form_data()))
+            await asyncio.sleep(0.05)
+            assert not second_entered.is_set()
+
+            release_first.set()
+
+            first_response = await first_request
+            second_response = await second_request
+    finally:
+        backend_main.__dict__["_score_response_from_cache_or_repository"] = original_builder
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert second_entered.is_set()
+
+
+@pytest.mark.anyio
+async def test_score_endpoint_releases_semaphore_after_failed_request() -> None:
+    entered = threading.Event()
+    release_first = threading.Event()
+    second_entered = threading.Event()
+    call_count = 0
+    lock = threading.Lock()
+    original_builder = backend_main.__dict__["_score_response_from_cache_or_repository"]
+    app = create_app(climate_repository=StubClimateRepository())
+
+    def flaky_builder(*args: object) -> ScoreResponse:
+        nonlocal call_count
+        with lock:
+            call_count += 1
+            current_call = call_count
+
+        if current_call == 1:
+            entered.set()
+            assert release_first.wait(timeout=1)
+            msg = "boom"
+            raise ClimateDataError(msg)
+
+        second_entered.set()
+        return {"scores": [], "heatmap": ""}
+
+    backend_main.__dict__["_score_response_from_cache_or_repository"] = flaky_builder
+
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+            first_request = asyncio.create_task(async_client.post("/score", data=default_form_data()))
+            await wait_for_thread_event(entered)
+
+            second_request = asyncio.create_task(async_client.post("/score", data=default_form_data()))
+            await asyncio.sleep(0.05)
+            assert not second_entered.is_set()
+
+            release_first.set()
+
+            first_response = await first_request
+            second_response = await second_request
+    finally:
+        backend_main.__dict__["_score_response_from_cache_or_repository"] = original_builder
+
+    assert first_response.status_code == 503
+    assert second_response.status_code == 200
+    assert second_entered.is_set()
 
 
 def test_score_endpoint_uses_gzip_when_requested() -> None:

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -125,7 +125,7 @@ def test_home_page_renders() -> None:
     assert "POGODAPP" in response.text
     assert "Pick the climate you like and see where it shows up." in response.text
     assert 'hx-post="/score"' in response.text
-    assert 'hx-trigger="load, change"' in response.text
+    assert 'hx-trigger="load, change delay:500ms"' in response.text
     assert 'hx-sync="this:replace"' in response.text
     assert 'hx-swap="none"' in response.text
     assert 'id="map-description"' in response.text

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -128,6 +128,7 @@ def test_home_page_renders() -> None:
     assert 'hx-trigger="load, change delay:500ms"' in response.text
     assert 'hx-sync="this:replace"' in response.text
     assert 'hx-swap="none"' in response.text
+    assert 'id="score-loading-indicator"' in response.text
     assert 'id="map-description"' in response.text
     assert 'id="map-status"' in response.text
     assert 'id="map-legend"' in response.text
@@ -970,7 +971,9 @@ def test_home_page_registers_htmx_handoff_script() -> None:
     assert app_script.status_code == 200
     assert "/static/app.js" in response.text
     assert "htmx:afterRequest" in app_script.text
+    assert "htmx:beforeRequest" in app_script.text
     assert "window.renderScores(JSON.parse(event.detail.xhr.responseText));" in app_script.text
+    assert "loadingIndicator.hidden = !isLoading;" in app_script.text
     assert "summerHeatInput.min = preferredDayInput.value" in app_script.text
     assert "winterColdInput.max = preferredDayInput.value" in app_script.text
 

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -17,6 +17,8 @@ from backend.main import build_probe_response, create_app
 from backend.scoring import ClimateCell, ClimateMatrix, PreferenceInputs, score_matrix_row_breakdown, score_preferences
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from _pytest.logging import LogCaptureFixture
     from _pytest.monkeypatch import MonkeyPatch
 
@@ -123,7 +125,7 @@ def test_home_page_renders() -> None:
     assert "POGODAPP" in response.text
     assert "Pick the climate you like and see where it shows up." in response.text
     assert 'hx-post="/score"' in response.text
-    assert 'hx-trigger="load, input changed delay:300ms"' in response.text
+    assert 'hx-trigger="load, change"' in response.text
     assert 'hx-sync="this:replace"' in response.text
     assert 'hx-swap="none"' in response.text
     assert 'id="map-description"' in response.text
@@ -483,6 +485,24 @@ def test_score_endpoint_accepts_form_encoded_preferences() -> None:
     assert payload["heatmap"].startswith("data:image/png;base64,")
 
 
+def test_score_endpoint_offloads_scoring_to_threadpool(monkeypatch: MonkeyPatch) -> None:
+    calls: list[tuple[object, tuple[object, ...]]] = []
+    app = create_app(climate_repository=StubClimateRepository())
+    threadpool_client = TestClient(app)
+
+    async def fake_run_in_threadpool(func: Callable[..., object], *args: object) -> object:
+        calls.append((func, args))
+        return func(*args)
+
+    monkeypatch.setattr(backend_main, "run_in_threadpool", fake_run_in_threadpool)
+
+    response = threadpool_client.post("/score", data=default_form_data())
+
+    assert response.status_code == 200
+    assert len(calls) == 1
+    assert getattr(calls[0][0], "__name__", "") == "_score_response_from_cache_or_repository"
+
+
 def test_score_endpoint_uses_gzip_when_requested() -> None:
     response = client.post(
         "/score",
@@ -840,6 +860,32 @@ def test_probe_endpoint_returns_scored_breakdown_for_a_valid_cell() -> None:
     assert len(payload["metrics"]) == 5
     assert [metric["key"] for metric in payload["metrics"]] == ["temp", "high", "low", "rain", "sun"]
     assert all(set(metric) == {"key", "label", "value", "display_value", "score"} for metric in payload["metrics"])
+
+
+def test_probe_endpoint_offloads_breakdown_to_threadpool(monkeypatch: MonkeyPatch) -> None:
+    class ProbeRepository(StubClimateRepository):
+        def probe_nearest_cell(self, lat: float, lon: float) -> int | None:
+            return 0
+
+        def get_probe_cell(self, row_index: int) -> ClimateCell:
+            return self.list_cells()[row_index]
+
+    calls: list[tuple[object, tuple[object, ...]]] = []
+    app = create_app(climate_repository=ProbeRepository())
+    threadpool_client = TestClient(app)
+
+    async def fake_run_in_threadpool(func: Callable[..., object], *args: object) -> object:
+        calls.append((func, args))
+        return func(*args)
+
+    monkeypatch.setattr(backend_main, "run_in_threadpool", fake_run_in_threadpool)
+
+    response = threadpool_client.get("/probe", params=default_query_params())
+
+    assert response.status_code == 200
+    assert response.json()["found"] is True
+    assert len(calls) == 1
+    assert getattr(calls[0][0], "__name__", "") == "_build_probe_response_from_repository"
 
 
 def test_probe_endpoint_uses_probe_cell_without_loading_resident_matrix() -> None:


### PR DESCRIPTION
## Summary
- switch the HTMX score trigger from live slider input to debounced settled `change` events so quick slider edits collapse into one `/score` request
- offload `/score` and `/probe` sync compute paths to Starlette's threadpool, serialize `/score` work per worker, and show a brief controls-panel loading state while rescoring is in flight
- add route coverage for threadpool handoff plus `/score` semaphore serialization and permit release after failures, and refresh README notes for the updated interaction model

## Testing
- `uv run ruff check backend/main.py tests/test_app_shell.py`
- `uv run pytest tests/test_app_shell.py`

## Notes
- This is still an #70 hardening slice, not a full architecture change.
- Not implemented: cross-worker score coordination, overload rejection/backpressure policy, or a browser-level frontend harness for debounce/loading behavior.
- Current deployment measurements look stable for the personal-site target: `/score` remains expensive but bounded, while `/` and `/probe` stay responsive during interaction.
