### PR TITLE
Fix silent /score validation failures in controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,16 @@ It is not a weather app. It scores long-term climate normals against a few user 
 - `/score` is rate-limited to `30/minute` per client and returns `429` when that limit is exceeded.
 - `GET /probe` accepts the same preference fields plus `lat` and `lon`, then returns `{"found": bool, "overall_score": 0..1, "metrics": [{"key", "label", "value", "display_value", "score"}, ...]}`.
 - `/probe` is rate-limited to `120/minute` per client and returns `429` when that limit is exceeded.
-- Both `/score` and `/probe` return `422` when `preferred_day_temperature` falls above `summer_heat_limit` or below `winter_cold_limit`.
+- `preferred_day_temperature` accepts `-5..35`.
+- `summer_heat_limit` accepts `-5..42` and must stay greater than or equal to `preferred_day_temperature`.
+- `winter_cold_limit` accepts `-15..35` and must stay less than or equal to `preferred_day_temperature`.
+- Both `/score` and `/probe` return `422` when those temperature fields violate the ordering rule.
 - `/probe` metric keys are `temp`, `high`, `low`, `rain`, and `sun`.
 - `/probe` temperature metrics mean: `temp` = typical day from median monthly high, `high` = hottest-month high, `low` = coldest-month low.
 - `/probe` returns `{"found": false, "overall_score": 0.0, "metrics": []}` for ocean points, unmapped cells, or repositories without probe support.
 - FastAPI handles HTTP and validation.
 - Scoring, ranking, and heatmap rendering stay out of the route layer.
-- `frontend/static/map.js` only renders. HTMX submits the form, shows a brief `Calculating...` status in the controls panel, and hands the JSON response to the map code.
+- `frontend/static/map.js` only renders. HTMX submits the form, shows a brief `Calculating...` status in the controls panel, and hands the JSON response to the map code. If scoring fails, the controls panel shows a generic inline error.
 - Tooltip probes snap hover points to the climate grid and cache results by snapped cell plus current preferences.
 
 ## Data

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ It is not a weather app. It scores long-term climate normals against a few user 
 - `/probe` returns `{"found": false, "overall_score": 0.0, "metrics": []}` for ocean points, unmapped cells, or repositories without probe support.
 - FastAPI handles HTTP and validation.
 - Scoring, ranking, and heatmap rendering stay out of the route layer.
-- `frontend/static/map.js` only renders. HTMX submits the form, shows a brief `Calculating...` status in the controls panel, and hands the JSON response to the map code. If scoring fails, the controls panel shows a generic inline error.
+- `frontend/static/map.js` only renders. HTMX submits the form, shows a brief `Calculating...` status in the controls panel, and hands the JSON response to the map code. Any non-`200` `/score` response shows a generic inline error in the controls panel.
 - Tooltip probes snap hover points to the climate grid and cache results by snapped cell plus current preferences.
 
 ## Data

--- a/backend/config.py
+++ b/backend/config.py
@@ -51,8 +51,8 @@ MAP_PROJECTION = MapProjection(
 
 
 # These ranges define the current UI and `/score` contract.
-# The scoring still runs on monthly mean temperature until the dataset grows
-# dedicated high/low temperature normals.
+# The temperature controls map to the high/low-based scoring inputs described
+# in `backend.scoring.PreferenceInputs`.
 DEFAULT_PREFERENCES: tuple[PreferenceField, ...] = (
     PreferenceField(
         name="preferred_day_temperature",

--- a/backend/config.py
+++ b/backend/config.py
@@ -57,7 +57,7 @@ DEFAULT_PREFERENCES: tuple[PreferenceField, ...] = (
     PreferenceField(
         name="preferred_day_temperature",
         label="Typical day",
-        minimum=5,
+        minimum=-5,
         maximum=35,
         step=1,
         value=18,
@@ -68,7 +68,7 @@ DEFAULT_PREFERENCES: tuple[PreferenceField, ...] = (
     PreferenceField(
         name="summer_heat_limit",
         label="Summer limit",
-        minimum=18,
+        minimum=-5,
         maximum=42,
         step=1,
         value=30,
@@ -80,7 +80,7 @@ DEFAULT_PREFERENCES: tuple[PreferenceField, ...] = (
         name="winter_cold_limit",
         label="Winter limit",
         minimum=-15,
-        maximum=20,
+        maximum=35,
         step=1,
         value=0,
         description="How cold can cooler months get before the place starts feeling too cold?",

--- a/backend/main.py
+++ b/backend/main.py
@@ -246,9 +246,9 @@ def _build_probe_response_from_repository(
 
 
 def probe_preferences_dependency(
-    preferred_day_temperature: Annotated[int, Query(ge=5, le=35)],
-    summer_heat_limit: Annotated[int, Query(ge=18, le=42)],
-    winter_cold_limit: Annotated[int, Query(ge=-15, le=20)],
+    preferred_day_temperature: Annotated[int, Query(ge=-5, le=35)],
+    summer_heat_limit: Annotated[int, Query(ge=-5, le=42)],
+    winter_cold_limit: Annotated[int, Query(ge=-15, le=35)],
     dryness_preference: Annotated[int, Query(ge=0, le=100)],
     sunshine_preference: Annotated[int, Query(ge=0, le=100)],
 ) -> PreferenceInputs:

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -36,9 +36,9 @@ MULTIPLICATIVE_SCORE_FLOOR = 0.02
 class PreferenceInputs(BaseModel):
     """Validated scoring inputs for the `/score` workflow."""
 
-    preferred_day_temperature: int = Field(ge=5, le=35)
-    summer_heat_limit: int = Field(ge=18, le=42)
-    winter_cold_limit: int = Field(ge=-15, le=20)
+    preferred_day_temperature: int = Field(ge=-5, le=35)
+    summer_heat_limit: int = Field(ge=-5, le=42)
+    winter_cold_limit: int = Field(ge=-15, le=35)
     dryness_preference: int = Field(ge=0, le=100)
     sunshine_preference: int = Field(ge=0, le=100)
 

--- a/frontend/static/app.js
+++ b/frontend/static/app.js
@@ -32,8 +32,14 @@ function constrainTemperatureControls(form) {
   if (!(winterColdInput instanceof HTMLInputElement)) return;
 
   const preferredDayValue = Number(preferredDayInput.value);
-  summerHeatInput.min = preferredDayInput.value;
-  winterColdInput.max = preferredDayInput.value;
+  const summerHeatMinimum = Number(summerHeatInput.dataset.minimum || summerHeatInput.min);
+  const winterColdMaximum = Number(winterColdInput.dataset.maximum || winterColdInput.max);
+
+  summerHeatInput.dataset.minimum = String(summerHeatMinimum);
+  winterColdInput.dataset.maximum = String(winterColdMaximum);
+
+  summerHeatInput.min = String(Math.max(summerHeatMinimum, preferredDayValue));
+  winterColdInput.max = String(Math.min(winterColdMaximum, preferredDayValue));
 
   if (Number(summerHeatInput.value) < preferredDayValue) {
     summerHeatInput.value = preferredDayInput.value;
@@ -85,27 +91,6 @@ function bindScoreHandoff(form) {
     errorIndicator.textContent = message;
   };
 
-  const scoreErrorMessage = (xhr) => {
-    if (xhr.status === 422) {
-      try {
-        const payload = JSON.parse(xhr.responseText);
-        const detail = Array.isArray(payload.detail) ? payload.detail : [];
-        if (detail.some((item) => String(item.msg || "").includes("summer_heat_limit"))) {
-          return "Typical day cannot be above too hot.";
-        }
-        if (detail.some((item) => String(item.msg || "").includes("winter_cold_limit"))) {
-          return "Typical day cannot be below too cold.";
-        }
-      } catch {
-        return "Those temperature limits conflict.";
-      }
-
-      return "Those temperature limits conflict.";
-    }
-
-    return "Could not score these preferences.";
-  };
-
   document.body.addEventListener("htmx:beforeRequest", (event) => {
     if (event.detail.elt !== form) return;
     setError("");
@@ -117,7 +102,7 @@ function bindScoreHandoff(form) {
     if (event.detail.elt !== form) return;
     setLoading(false);
     if (event.detail.xhr.status !== 200) {
-      setError(scoreErrorMessage(event.detail.xhr));
+      setError("Could not calculate scores.");
       return;
     }
 

--- a/frontend/static/app.js
+++ b/frontend/static/app.js
@@ -72,14 +72,43 @@ function bindPreferenceControls(form) {
 
 function bindScoreHandoff(form) {
   const loadingIndicator = document.getElementById("score-loading-indicator");
+  const errorIndicator = document.getElementById("score-error-indicator");
 
   const setLoading = (isLoading) => {
     if (!loadingIndicator) return;
     loadingIndicator.hidden = !isLoading;
   };
 
+  const setError = (message) => {
+    if (!(errorIndicator instanceof HTMLElement)) return;
+    errorIndicator.hidden = message.length === 0;
+    errorIndicator.textContent = message;
+  };
+
+  const scoreErrorMessage = (xhr) => {
+    if (xhr.status === 422) {
+      try {
+        const payload = JSON.parse(xhr.responseText);
+        const detail = Array.isArray(payload.detail) ? payload.detail : [];
+        if (detail.some((item) => String(item.msg || "").includes("summer_heat_limit"))) {
+          return "Typical day cannot be above too hot.";
+        }
+        if (detail.some((item) => String(item.msg || "").includes("winter_cold_limit"))) {
+          return "Typical day cannot be below too cold.";
+        }
+      } catch {
+        return "Those temperature limits conflict.";
+      }
+
+      return "Those temperature limits conflict.";
+    }
+
+    return "Could not score these preferences.";
+  };
+
   document.body.addEventListener("htmx:beforeRequest", (event) => {
     if (event.detail.elt !== form) return;
+    setError("");
     setLoading(true);
   });
 
@@ -87,7 +116,12 @@ function bindScoreHandoff(form) {
   document.body.addEventListener("htmx:afterRequest", (event) => {
     if (event.detail.elt !== form) return;
     setLoading(false);
-    if (event.detail.xhr.status !== 200) return;
+    if (event.detail.xhr.status !== 200) {
+      setError(scoreErrorMessage(event.detail.xhr));
+      return;
+    }
+
+    setError("");
     window.renderScores(JSON.parse(event.detail.xhr.responseText));
   });
 }

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -168,6 +168,24 @@ ul {
   display: none;
 }
 
+.score-request-status {
+  min-height: 0.85rem;
+}
+
+.score-error-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #ff7a7a;
+}
+
+.score-error-indicator[hidden] {
+  display: none;
+}
+
 .score-loading-indicator__spinner {
   width: 0.75rem;
   height: 0.75rem;

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -28,9 +28,12 @@
       <section class="app-panel controls-panel" aria-label="Controls area">
         <div class="panel-header">
           <h2>Controls</h2>
-          <div id="score-loading-indicator" class="score-loading-indicator" role="status" aria-live="polite" hidden>
-            <span class="score-loading-indicator__spinner" aria-hidden="true"></span>
-            <span>Calculating...</span>
+          <div class="score-request-status" aria-live="polite">
+            <div id="score-loading-indicator" class="score-loading-indicator" role="status" hidden>
+              <span class="score-loading-indicator__spinner" aria-hidden="true"></span>
+              <span>Calculating...</span>
+            </div>
+            <div id="score-error-indicator" class="score-error-indicator" role="alert" hidden></div>
           </div>
         </div>
         <form

--- a/tests/test_app_frontend.py
+++ b/tests/test_app_frontend.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def _run_app_runtime_scenario(scenario: str) -> None:
+    root = Path(__file__).resolve().parents[1]
+    app_script = (root / "frontend" / "static" / "app.js").read_text(encoding="utf-8")
+    script = textwrap.dedent(
+        rf"""
+        const vm = require("node:vm");
+
+        class HTMLElementStub {{
+          constructor(id = "") {{
+            this.id = id;
+            this.hidden = false;
+            this.textContent = "";
+            this.value = "";
+            this.dataset = {{}};
+            this.style = {{
+              values: new Map(),
+              setProperty(name, value) {{
+                this.values.set(name, value);
+              }},
+            }};
+          }}
+        }}
+
+        class HTMLInputElementStub extends HTMLElementStub {{
+          constructor(id, name, min, max, value, field) {{
+            super(id);
+            this.name = name;
+            this.min = String(min);
+            this.max = String(max);
+            this.step = "1";
+            this.value = String(value);
+            this.type = "range";
+            this.dataset = {{ field }};
+            this.listeners = new Map();
+          }}
+
+          addEventListener(name, handler) {{
+            this.listeners.set(name, handler);
+          }}
+        }}
+
+        class HTMLOutputElementStub extends HTMLElementStub {{
+          constructor(id, htmlFor) {{
+            super(id);
+            this.htmlFor = htmlFor;
+          }}
+        }}
+
+        const bodyHandlers = new Map();
+        const documentHandlers = new Map();
+        const renderCalls = [];
+
+        const preferredDayInput = new HTMLInputElementStub("preferred_day_temperature", "preferred_day_temperature", -5, 35, 22, "preferred_day_temperature");
+        const summerHeatInput = new HTMLInputElementStub("summer_heat_limit", "summer_heat_limit", -5, 42, 10, "summer_heat_limit");
+        const winterColdInput = new HTMLInputElementStub("winter_cold_limit", "winter_cold_limit", -15, 35, 30, "winter_cold_limit");
+        const drynessInput = new HTMLInputElementStub("dryness_preference", "dryness_preference", 0, 100, 60, "dryness_preference");
+        const sunshineInput = new HTMLInputElementStub("sunshine_preference", "sunshine_preference", 0, 100, 60, "sunshine_preference");
+        const inputs = [preferredDayInput, summerHeatInput, winterColdInput, drynessInput, sunshineInput];
+
+        const outputs = new Map(inputs.map((input) => [input.id, new HTMLOutputElementStub(`${{input.id}}-output`, input.id)]));
+        const loadingIndicator = new HTMLElementStub("score-loading-indicator");
+        loadingIndicator.hidden = true;
+        const errorIndicator = new HTMLElementStub("score-error-indicator");
+        errorIndicator.hidden = true;
+
+        const form = new HTMLElementStub("preferences");
+        form.elements = {{
+          namedItem(name) {{
+            return inputs.find((input) => input.name === name) ?? null;
+          }},
+        }};
+        form.querySelectorAll = (selector) => selector === "input[type='range']" ? inputs : [];
+        form.querySelector = (selector) => {{
+          const match = selector.match(/^output\[for='(.+)'\]$/);
+          return match ? outputs.get(match[1]) ?? null : null;
+        }};
+
+        globalThis.window = globalThis;
+        globalThis.HTMLElement = HTMLElementStub;
+        globalThis.HTMLInputElement = HTMLInputElementStub;
+        globalThis.document = {{
+          readyState: "complete",
+          body: {{
+            addEventListener(name, handler) {{
+              bodyHandlers.set(name, handler);
+            }},
+          }},
+          addEventListener(name, handler) {{
+            documentHandlers.set(name, handler);
+          }},
+          getElementById(id) {{
+            if (id === "preferences") return form;
+            if (id === "score-loading-indicator") return loadingIndicator;
+            if (id === "score-error-indicator") return errorIndicator;
+            return null;
+          }},
+        }};
+        globalThis.renderScores = (payload) => {{
+          renderCalls.push(payload);
+        }};
+
+        vm.runInThisContext({app_script!r});
+
+        const triggerBody = (name, detail) => {{
+          const handler = bodyHandlers.get(name);
+          if (!handler) throw new Error(`missing body handler ${{name}}`);
+          handler({{ detail }});
+        }};
+
+        {scenario}
+        """
+    )
+
+    result = subprocess.run(["node", "-e", script], cwd=root, capture_output=True, text=True, check=False)  # noqa: S603,S607
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_app_runtime_preserves_original_slider_bounds_when_typical_day_changes() -> None:
+    _run_app_runtime_scenario(
+        textwrap.dedent(
+            """
+            if (summerHeatInput.min !== "22") throw new Error(`expected initial summer min 22, got ${summerHeatInput.min}`);
+            if (winterColdInput.max !== "22") throw new Error(`expected initial winter max 22, got ${winterColdInput.max}`);
+            if (summerHeatInput.value !== "22") throw new Error(`expected summer value clamped to 22, got ${summerHeatInput.value}`);
+            if (winterColdInput.value !== "22") throw new Error(`expected winter value clamped to 22, got ${winterColdInput.value}`);
+
+            preferredDayInput.value = "35";
+            preferredDayInput.listeners.get("input")();
+
+            if (summerHeatInput.min !== "35") throw new Error(`expected summer min 35, got ${summerHeatInput.min}`);
+            if (winterColdInput.max !== "35") throw new Error(`expected winter max restored to 35, got ${winterColdInput.max}`);
+
+            preferredDayInput.value = "-5";
+            preferredDayInput.listeners.get("input")();
+
+            if (summerHeatInput.min !== "-5") throw new Error(`expected summer min restored to -5, got ${summerHeatInput.min}`);
+            if (winterColdInput.max !== "-5") throw new Error(`expected winter max lowered to -5, got ${winterColdInput.max}`);
+            if (winterColdInput.value !== "-5") throw new Error(`expected winter value clamped to -5, got ${winterColdInput.value}`);
+            """
+        )
+    )
+
+
+def test_app_runtime_shows_generic_error_and_clears_it_after_success() -> None:
+    _run_app_runtime_scenario(
+        textwrap.dedent(
+            """
+            triggerBody("htmx:beforeRequest", { elt: form });
+            if (loadingIndicator.hidden) throw new Error("loading indicator should show before request");
+            if (!errorIndicator.hidden) throw new Error("error indicator should be hidden before request");
+
+            triggerBody("htmx:afterRequest", { elt: form, xhr: { status: 503, responseText: '{"detail":"boom"}' } });
+
+            if (!loadingIndicator.hidden) throw new Error("loading indicator should hide after failed request");
+            if (errorIndicator.hidden) throw new Error("error indicator should show after failed request");
+            if (errorIndicator.textContent !== "Could not calculate scores.") throw new Error(`unexpected error text ${errorIndicator.textContent}`);
+            if (renderCalls.length !== 0) throw new Error("failed request should not render scores");
+
+            triggerBody("htmx:beforeRequest", { elt: form });
+            triggerBody("htmx:afterRequest", { elt: form, xhr: { status: 200, responseText: '{"scores":[],"heatmap":""}' } });
+
+            if (!errorIndicator.hidden) throw new Error("successful request should clear error indicator");
+            if (!loadingIndicator.hidden) throw new Error("loading indicator should stay hidden after success");
+            if (renderCalls.length !== 1) throw new Error(`expected one render call, got ${renderCalls.length}`);
+            """
+        )
+    )

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -143,6 +143,7 @@ def test_home_page_renders() -> None:
     assert 'hx-sync="this:replace"' in response.text
     assert 'hx-swap="none"' in response.text
     assert 'id="score-loading-indicator"' in response.text
+    assert 'id="score-error-indicator"' in response.text
     assert 'id="map-description"' in response.text
     assert 'id="map-status"' in response.text
     assert 'id="map-legend"' in response.text
@@ -1085,6 +1086,9 @@ def test_home_page_registers_htmx_handoff_script() -> None:
     assert "htmx:beforeRequest" in app_script.text
     assert "window.renderScores(JSON.parse(event.detail.xhr.responseText));" in app_script.text
     assert "loadingIndicator.hidden = !isLoading;" in app_script.text
+    assert 'const errorIndicator = document.getElementById("score-error-indicator");' in app_script.text
+    assert "if (event.detail.xhr.status !== 200) {" in app_script.text
+    assert "Could not score these preferences." in app_script.text
     assert "summerHeatInput.min = preferredDayInput.value" in app_script.text
     assert "winterColdInput.max = preferredDayInput.value" in app_script.text
 

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -898,6 +898,20 @@ def test_score_endpoint_rejects_typical_day_below_winter_limit() -> None:
     assert any("winter_cold_limit" in item["msg"] for item in detail)
 
 
+def test_score_endpoint_accepts_mild_winter_limit_above_20_when_ordered() -> None:
+    response = client.post(
+        "/score",
+        data={
+            **default_form_data(),
+            "preferred_day_temperature": "22",
+            "summer_heat_limit": "23",
+            "winter_cold_limit": "21",
+        },
+    )
+
+    assert response.status_code == 200
+
+
 def test_probe_endpoint_rejects_typical_day_above_summer_limit() -> None:
     response = client.get(
         "/probe",
@@ -1088,9 +1102,10 @@ def test_home_page_registers_htmx_handoff_script() -> None:
     assert "loadingIndicator.hidden = !isLoading;" in app_script.text
     assert 'const errorIndicator = document.getElementById("score-error-indicator");' in app_script.text
     assert "if (event.detail.xhr.status !== 200) {" in app_script.text
-    assert "Could not score these preferences." in app_script.text
-    assert "summerHeatInput.min = preferredDayInput.value" in app_script.text
-    assert "winterColdInput.max = preferredDayInput.value" in app_script.text
+    assert "Could not calculate scores." in app_script.text
+    assert "summerHeatInput.min = String(Math.max(summerHeatMinimum, preferredDayValue));" in app_script.text
+    assert "winterColdInput.max = String(Math.min(winterColdMaximum, preferredDayValue));" in app_script.text
+    assert "scoreErrorMessage" not in app_script.text
 
 
 def test_map_script_renders_city_labels_instead_of_coordinates() -> None:

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -946,6 +946,34 @@ def test_probe_endpoint_rejects_typical_day_below_winter_limit() -> None:
     assert any("winter_cold_limit" in item["msg"] for item in detail)
 
 
+def test_probe_endpoint_accepts_widened_temperature_bounds_when_ordered() -> None:
+    response = client.get(
+        "/probe",
+        params={
+            **default_query_params(),
+            "preferred_day_temperature": -5,
+            "summer_heat_limit": -5,
+            "winter_cold_limit": -15,
+        },
+    )
+
+    assert response.status_code == 200
+
+
+def test_probe_endpoint_accepts_mild_winter_limit_up_to_typical_day() -> None:
+    response = client.get(
+        "/probe",
+        params={
+            **default_query_params(),
+            "preferred_day_temperature": 35,
+            "summer_heat_limit": 42,
+            "winter_cold_limit": 35,
+        },
+    )
+
+    assert response.status_code == 200
+
+
 def test_score_endpoint_returns_all_available_cities_when_under_continent_reserve() -> None:
     many_cities_client = TestClient(create_app(climate_repository=cast("ClimateRepository", ManyCitiesRepository())))
 


### PR DESCRIPTION
## Summary
- simplify the temperature preference contract to broad ranges plus ordering-only validation
- keep the controls aligned with backend ordering rules and fall back to one generic inline error for non-`200` `/score` responses
- add `/probe` widened-bound coverage and runtime frontend tests for slider constraint restoration, clamping, and error recovery

## Testing
- `uv run pytest tests/test_app_shell.py tests/test_app_frontend.py`
- `uv run ruff check tests/test_app_shell.py tests/test_app_frontend.py backend/config.py README.md`
- `node --check "frontend/static/app.js"`

## Review
- follow-up review pass found no meaningful remaining issues
