### PR TITLE
Harden /score validation handling in controls

### DIFF
--- a/frontend/static/app.js
+++ b/frontend/static/app.js
@@ -60,6 +60,23 @@ function syncRangeControl(input, output) {
   if (output) output.value = formatControlValue(input);
 }
 
+function extractScoreErrorMessage(xhr) {
+  if (xhr.status === 422) {
+    try {
+      const payload = JSON.parse(xhr.responseText);
+      const detail = Array.isArray(payload.detail) ? payload.detail : [];
+      const firstMessage = detail.find((item) => typeof item?.msg === "string")?.msg;
+      if (firstMessage) return firstMessage;
+    } catch {
+      return "Invalid preferences.";
+    }
+
+    return "Invalid preferences.";
+  }
+
+  return "Could not calculate scores.";
+}
+
 function bindPreferenceControls(form) {
   const syncAllControls = () => {
     constrainTemperatureControls(form);
@@ -74,9 +91,10 @@ function bindPreferenceControls(form) {
   }
 
   syncAllControls();
+  return syncAllControls;
 }
 
-function bindScoreHandoff(form) {
+function bindScoreHandoff(form, syncControls) {
   const loadingIndicator = document.getElementById("score-loading-indicator");
   const errorIndicator = document.getElementById("score-error-indicator");
 
@@ -93,6 +111,7 @@ function bindScoreHandoff(form) {
 
   document.body.addEventListener("htmx:beforeRequest", (event) => {
     if (event.detail.elt !== form) return;
+    syncControls();
     setError("");
     setLoading(true);
   });
@@ -102,7 +121,7 @@ function bindScoreHandoff(form) {
     if (event.detail.elt !== form) return;
     setLoading(false);
     if (event.detail.xhr.status !== 200) {
-      setError("Could not calculate scores.");
+      setError(extractScoreErrorMessage(event.detail.xhr));
       return;
     }
 
@@ -114,8 +133,8 @@ function bindScoreHandoff(form) {
 function initializeAppShell() {
   const form = document.getElementById("preferences");
   if (!form) return;
-  bindPreferenceControls(form);
-  bindScoreHandoff(form);
+  const syncControls = bindPreferenceControls(form);
+  bindScoreHandoff(form, syncControls);
   if (window.POGODAPP_INITIAL_SCORES) {
     window.renderScores(window.POGODAPP_INITIAL_SCORES);
   }

--- a/tests/test_app_frontend.py
+++ b/tests/test_app_frontend.py
@@ -172,3 +172,46 @@ def test_app_runtime_shows_generic_error_and_clears_it_after_success() -> None:
             """
         )
     )
+
+
+def test_app_runtime_resyncs_temperature_controls_before_htmx_submit() -> None:
+    _run_app_runtime_scenario(
+        textwrap.dedent(
+            """
+            preferredDayInput.value = "18";
+            summerHeatInput.min = "-5";
+            summerHeatInput.value = "10";
+            winterColdInput.max = "35";
+            winterColdInput.value = "20";
+
+            triggerBody("htmx:beforeRequest", { elt: form });
+
+            if (summerHeatInput.min !== "18") throw new Error(`expected summer min 18, got ${summerHeatInput.min}`);
+            if (summerHeatInput.value !== "18") throw new Error(`expected summer value clamped to 18, got ${summerHeatInput.value}`);
+            if (winterColdInput.max !== "18") throw new Error(`expected winter max 18, got ${winterColdInput.max}`);
+            if (winterColdInput.value !== "18") throw new Error(`expected winter value clamped to 18, got ${winterColdInput.value}`);
+            """
+        )
+    )
+
+
+def test_app_runtime_surfaces_validation_error_message_for_invalid_preferences() -> None:
+    _run_app_runtime_scenario(
+        textwrap.dedent(
+            """
+            triggerBody("htmx:beforeRequest", { elt: form });
+            triggerBody("htmx:afterRequest", {
+              elt: form,
+              xhr: {
+                status: 422,
+                responseText: '{"detail":[{"msg":"preferred_day_temperature must be greater than or equal to winter_cold_limit"}]}'
+              }
+            });
+
+            if (errorIndicator.hidden) throw new Error("validation error should show");
+            if (errorIndicator.textContent !== "preferred_day_temperature must be greater than or equal to winter_cold_limit") {
+              throw new Error(`unexpected validation text ${errorIndicator.textContent}`);
+            }
+            """
+        )
+    )


### PR DESCRIPTION
## Summary
- resync the existing temperature slider constraints immediately before HTMX submits `/score`
- surface backend `422` validation messages in the controls area instead of only showing a generic score failure
- add frontend runtime coverage for submit-time resync and validation-error display

Closes #66 

## Testing
- uv run pytest tests/test_app_frontend.py tests/test_app_shell.py -q