### PR TITLE
Instrument /score cache and timing logs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 from dataclasses import asdict
 from pathlib import Path
 from time import perf_counter
-from typing import TYPE_CHECKING, Annotated, Protocol, cast
+from typing import TYPE_CHECKING, Annotated, NamedTuple, Protocol, cast
 
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
 from fastapi.exceptions import RequestValidationError
@@ -85,12 +85,19 @@ class _ScoreResponseCache:
         key: tuple[int, int, int, int, int],
         build: Callable[[], ScoreResponse],
     ) -> ScoreResponse:
+        return self.get_with_status_or_set(key, build).response
+
+    def get_with_status_or_set(
+        self,
+        key: tuple[int, int, int, int, int],
+        build: Callable[[], ScoreResponse],
+    ) -> _ScoreCacheResult:
         while True:
             with self._lock:
                 response = self._entries.get(key)
                 if response is not None:
                     self._entries.move_to_end(key)
-                    return response
+                    return _ScoreCacheResult(response=response, cache_hit=True)
 
                 inflight = self._inflight.get(key)
                 if inflight is None:
@@ -113,7 +120,12 @@ class _ScoreResponseCache:
             if len(self._entries) > self.max_entries:
                 self._entries.popitem(last=False)
             self._inflight.pop(key).set()
-            return response
+            return _ScoreCacheResult(response=response, cache_hit=False)
+
+
+class _ScoreCacheResult(NamedTuple):
+    response: ScoreResponse
+    cache_hit: bool
 
 
 class _SupportsProbeRepository(Protocol):
@@ -221,13 +233,29 @@ def _score_cache_key(preferences: PreferenceInputs) -> tuple[int, int, int, int,
     )
 
 
+def _score_log_fields(preferences: PreferenceInputs) -> dict[str, int]:
+    return {
+        "preferred_day_temperature": preferences.preferred_day_temperature,
+        "summer_heat_limit": preferences.summer_heat_limit,
+        "winter_cold_limit": preferences.winter_cold_limit,
+        "dryness_preference": preferences.dryness_preference,
+        "sunshine_preference": preferences.sunshine_preference,
+    }
+
+
 def _score_response_from_cache_or_repository(
     score_cache: _ScoreResponseCache,
     repository: ClimateRepository,
     preferences: PreferenceInputs,
-) -> ScoreResponse:
+) -> _ScoreCacheResult:
     cache_key = _score_cache_key(preferences)
-    return score_cache.get_or_set(cache_key, lambda: build_score_response(repository, preferences))
+    return score_cache.get_with_status_or_set(cache_key, lambda: build_score_response(repository, preferences))
+
+
+def _coerce_score_cache_result(result: _ScoreCacheResult | ScoreResponse) -> _ScoreCacheResult:
+    if isinstance(result, _ScoreCacheResult):
+        return result
+    return _ScoreCacheResult(response=result, cache_hit=False)
 
 
 def _build_probe_response_from_repository(
@@ -385,24 +413,35 @@ def create_app(
     @limiter.limit("30/minute")
     async def score(request: Request, preferences: Annotated[PreferenceInputs, Form()]) -> ScoreResponse:
         try:
+            queue_started = perf_counter()
             async with score_request_semaphore:
-                return await run_in_threadpool(
+                queue_wait_ms = round((perf_counter() - queue_started) * 1000, 2)
+                raw_cache_result = await run_in_threadpool(
                     _score_response_from_cache_or_repository, score_cache, repository, preferences
                 )
+            cache_result = _coerce_score_cache_result(raw_cache_result)
+            logger.info(
+                "score request served",
+                extra={
+                    "event": "score_request_route",
+                    "outcome": "ok",
+                    "cache_hit": cache_result.cache_hit,
+                    "queue_wait_ms": queue_wait_ms,
+                    **_score_log_fields(preferences),
+                },
+            )
         except ClimateDataError as error:
             logger.exception(
                 "score request failed",
                 extra={
                     "event": "score_request",
                     "outcome": "error",
-                    "preferred_day_temperature": preferences.preferred_day_temperature,
-                    "summer_heat_limit": preferences.summer_heat_limit,
-                    "winter_cold_limit": preferences.winter_cold_limit,
-                    "dryness_preference": preferences.dryness_preference,
-                    "sunshine_preference": preferences.sunshine_preference,
+                    **_score_log_fields(preferences),
                 },
             )
             raise HTTPException(status_code=503, detail=str(error)) from error
+        else:
+            return cache_result.response
 
     @app.get("/probe")
     @limiter.limit("120/minute")

--- a/backend/score_service.py
+++ b/backend/score_service.py
@@ -42,6 +42,7 @@ class ScoreTimings:
     normalize_ms: float = 0.0
     ranking_ms: float = 0.0
     heatmap_ms: float = 0.0
+    response_ms: float = 0.0
     total_ms: float = 0.0
 
 
@@ -70,6 +71,7 @@ def _elapsed_ms(start_time: float) -> float:
 def _empty_score_response(
     timings: ScoreTimings,
     *,
+    preferences: PreferenceInputs,
     request_started: float,
     context: ScoreContext,
     outcome: str,
@@ -77,6 +79,7 @@ def _empty_score_response(
     timings.total_ms = _elapsed_ms(request_started)
     _log_score_timings(
         timings,
+        preferences=preferences,
         climate_cell_count=context.climate_cell_count,
         city_count=context.city_count,
         ranked_city_count=0,
@@ -85,26 +88,31 @@ def _empty_score_response(
     return EMPTY_SCORE_RESPONSE
 
 
-def _finalize_score_response(
+def _finalize_score_response(  # noqa: PLR0913
     timings: ScoreTimings,
     *,
+    preferences: PreferenceInputs,
     request_started: float,
     context: ScoreContext,
     ranked_cities: list[CityScorePoint],
     heatmap_png: bytes,
 ) -> ScoreResponse:
+    response_started = perf_counter()
+    response: ScoreResponse = {
+        "scores": ranked_cities,
+        "heatmap": "data:image/png;base64," + base64.b64encode(heatmap_png).decode(),
+    }
+    timings.response_ms = _elapsed_ms(response_started)
     timings.total_ms = _elapsed_ms(request_started)
     _log_score_timings(
         timings,
+        preferences=preferences,
         climate_cell_count=context.climate_cell_count,
         city_count=context.city_count,
         ranked_city_count=len(ranked_cities),
         outcome="ok",
     )
-    return {
-        "scores": ranked_cities,
-        "heatmap": "data:image/png;base64," + base64.b64encode(heatmap_png).decode(),
-    }
+    return response
 
 
 def _filter_ranking_catalog(city_catalog: CityRankingCache) -> CityRankingCache:
@@ -266,9 +274,10 @@ def _rescore_city_points_from_cells(
     return _deduplicate_city_points(sorted(rescored, key=lambda city: city["score"], reverse=True))
 
 
-def _log_score_timings(
+def _log_score_timings(  # noqa: PLR0913
     timings: ScoreTimings,
     *,
+    preferences: PreferenceInputs,
     climate_cell_count: int,
     city_count: int,
     ranked_city_count: int,
@@ -286,9 +295,15 @@ def _log_score_timings(
             "normalize_ms": timings.normalize_ms,
             "ranking_ms": timings.ranking_ms,
             "heatmap_ms": timings.heatmap_ms,
+            "response_ms": timings.response_ms,
             "climate_cells": climate_cell_count,
             "cities": city_count,
             "ranked_cities": ranked_city_count,
+            "preferred_day_temperature": preferences.preferred_day_temperature,
+            "summer_heat_limit": preferences.summer_heat_limit,
+            "winter_cold_limit": preferences.winter_cold_limit,
+            "dryness_preference": preferences.dryness_preference,
+            "sunshine_preference": preferences.sunshine_preference,
         },
     )
 
@@ -331,6 +346,7 @@ def _build_score_response_from_matrix(
     if raw_scores.size == 0:
         return _empty_score_response(
             timings,
+            preferences=preferences,
             request_started=request_started,
             context=context,
             outcome="empty",
@@ -340,6 +356,7 @@ def _build_score_response_from_matrix(
     if max_score == 0.0:
         return _empty_score_response(
             timings,
+            preferences=preferences,
             request_started=request_started,
             context=context,
             outcome="all_zero",
@@ -371,6 +388,7 @@ def _build_score_response_from_matrix(
     timings.heatmap_ms = _elapsed_ms(heatmap_started)
     return _finalize_score_response(
         timings,
+        preferences=preferences,
         request_started=request_started,
         context=context,
         ranked_cities=top_cities,
@@ -401,6 +419,7 @@ def _build_score_response_from_cells(
     if not raw_scores:
         return _empty_score_response(
             timings,
+            preferences=preferences,
             request_started=request_started,
             context=context,
             outcome="empty",
@@ -411,6 +430,7 @@ def _build_score_response_from_cells(
         # An all-zero result carries no useful ranking or map signal for the UI.
         return _empty_score_response(
             timings,
+            preferences=preferences,
             request_started=request_started,
             context=context,
             outcome="all_zero",
@@ -437,6 +457,7 @@ def _build_score_response_from_cells(
     timings.heatmap_ms = _elapsed_ms(heatmap_started)
     return _finalize_score_response(
         timings,
+        preferences=preferences,
         request_started=request_started,
         context=context,
         ranked_cities=top_cities,

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -685,6 +685,50 @@ def test_score_endpoint_uses_prewarmed_default_preferences_cache() -> None:
     assert call_count == 1  # pre-warm only; the first default request should hit cache
 
 
+def test_score_endpoint_logs_cache_hit_and_miss_route_details(monkeypatch: MonkeyPatch) -> None:
+    route_events: list[dict[str, object]] = []
+    original_info = backend_main.logger.info
+
+    def capture_info(
+        msg: object,
+        *args: object,
+        extra: dict[str, object] | None = None,
+    ) -> None:
+        if msg == "score request served" and extra is not None:
+            route_events.append(extra.copy())
+        original_info(msg, *args, extra=extra)
+
+    monkeypatch.setattr(backend_main.logger, "info", capture_info)
+
+    cached_client = TestClient(create_app(climate_repository=StubClimateRepository()))
+    default_response = cached_client.post("/score", data=rendered_default_form_data())
+    custom_response = cached_client.post("/score", data=default_form_data())
+
+    assert default_response.status_code == 200
+    assert custom_response.status_code == 200
+
+    assert len(route_events) == 2
+    default_event, custom_event = route_events
+
+    assert default_event["event"] == "score_request_route"
+    assert default_event["cache_hit"] is True
+    assert cast("float", default_event["queue_wait_ms"]) >= 0
+    assert default_event["preferred_day_temperature"] == 18
+    assert default_event["summer_heat_limit"] == 30
+    assert default_event["winter_cold_limit"] == 0
+    assert default_event["dryness_preference"] == 30
+    assert default_event["sunshine_preference"] == 50
+
+    assert custom_event["event"] == "score_request_route"
+    assert custom_event["cache_hit"] is False
+    assert cast("float", custom_event["queue_wait_ms"]) >= 0
+    assert custom_event["preferred_day_temperature"] == 22
+    assert custom_event["summer_heat_limit"] == 30
+    assert custom_event["winter_cold_limit"] == 5
+    assert custom_event["dryness_preference"] == 60
+    assert custom_event["sunshine_preference"] == 60
+
+
 def test_score_endpoint_evicts_oldest_cached_preferences_after_cache_limit() -> None:
     call_count = 0
     original_builder = backend_main.build_score_response

--- a/tests/test_score_service.py
+++ b/tests/test_score_service.py
@@ -63,6 +63,12 @@ def test_build_score_response_logs_step_timings(caplog: LogCaptureFixture) -> No
     assert cast("float", record.__dict__["normalize_ms"]) >= 0
     assert cast("float", record.__dict__["ranking_ms"]) >= 0
     assert cast("float", record.__dict__["heatmap_ms"]) >= 0
+    assert cast("float", record.__dict__["response_ms"]) >= 0
+    assert record.__dict__["preferred_day_temperature"] == preferences.preferred_day_temperature
+    assert record.__dict__["summer_heat_limit"] == preferences.summer_heat_limit
+    assert record.__dict__["winter_cold_limit"] == preferences.winter_cold_limit
+    assert record.__dict__["dryness_preference"] == preferences.dryness_preference
+    assert record.__dict__["sunshine_preference"] == preferences.sunshine_preference
 
 
 def test_build_score_response_returns_empty_payload_for_empty_matrix() -> None:


### PR DESCRIPTION
## Summary
- add route-level `/score` observability for cache hits, queue wait, and the active preference tuple
- extend miss-path `score_request` logs with the preference tuple and response assembly timing
- add focused test coverage for the new logging fields without claiming issue #74 is resolved yet

## Why
This PR is instrumentation only so we can inspect real `/score` traffic before choosing the next optimization. It does not end #74 by itself.

## Testing
- uv run pytest tests/test_score_service.py tests/test_app_shell.py -q