### PR TITLE
Decouple /score results from heatmap rendering

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -32,7 +32,7 @@ from backend.climate_repository import (
 from backend.config import DEFAULT_PREFERENCES, MAP_PROJECTION
 from backend.logging_config import configure_backend_logging
 from backend.runtime import resolve_climate_database_path
-from backend.score_service import ScoreResponse, build_heatmap_response, build_score_response
+from backend.score_service import HeatmapField, ScoreResponse, build_heatmap_response, build_score_response
 from backend.scoring import (
     ClimateCell,
     PreferenceInputs,
@@ -55,6 +55,8 @@ logger = logging.getLogger(__name__)
 CLIENT_ERROR_STATUS_MIN = 400
 SERVER_ERROR_STATUS_MIN = 500
 SCORE_CACHE_SIZE = 16
+HEATMAP_FIELD_CACHE_SIZE = 2
+HEATMAP_FIELD_CACHE_TTL_SECONDS = 20.0
 
 
 class _ScoreResponseCache:
@@ -127,6 +129,40 @@ class _ScoreResponseCache:
 class _ScoreCacheResult(NamedTuple):
     response: ScoreResponse
     cache_hit: bool
+
+
+class _HeatmapFieldCache:
+    """Keep a tiny, short-lived score-field cache for `/heatmap` reuse."""
+
+    def __init__(self, max_entries: int, ttl_seconds: float) -> None:
+        self.max_entries = max_entries
+        self.ttl_seconds = ttl_seconds
+        self._entries: OrderedDict[tuple[int, int, int, int, int], tuple[float, HeatmapField]] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def get(self, key: tuple[int, int, int, int, int]) -> HeatmapField | None:
+        now = perf_counter()
+        with self._lock:
+            self._purge_expired(now)
+            cached = self._entries.get(key)
+            if cached is None:
+                return None
+            self._entries.move_to_end(key)
+            return cached[1]
+
+    def set(self, key: tuple[int, int, int, int, int], heatmap_field: HeatmapField) -> None:
+        now = perf_counter()
+        with self._lock:
+            self._purge_expired(now)
+            self._entries[key] = (now, heatmap_field)
+            self._entries.move_to_end(key)
+            if len(self._entries) > self.max_entries:
+                self._entries.popitem(last=False)
+
+    def _purge_expired(self, now: float) -> None:
+        expired_keys = [key for key, (stored_at, _field) in self._entries.items() if now - stored_at > self.ttl_seconds]
+        for key in expired_keys:
+            self._entries.pop(key, None)
 
 
 class _SupportsProbeRepository(Protocol):
@@ -246,11 +282,19 @@ def _score_log_fields(preferences: PreferenceInputs) -> dict[str, int]:
 
 def _score_response_from_cache_or_repository(
     score_cache: _ScoreResponseCache,
+    heatmap_field_cache: _HeatmapFieldCache,
     repository: ClimateRepository,
     preferences: PreferenceInputs,
 ) -> _ScoreCacheResult:
     cache_key = _score_cache_key(preferences)
-    return score_cache.get_with_status_or_set(cache_key, lambda: build_score_response(repository, preferences))
+    return score_cache.get_with_status_or_set(
+        cache_key,
+        lambda: build_score_response(
+            repository,
+            preferences,
+            store_heatmap_field=lambda heatmap_field: heatmap_field_cache.set(cache_key, heatmap_field),
+        ),
+    )
 
 
 def _coerce_score_cache_result(result: _ScoreCacheResult | ScoreResponse) -> _ScoreCacheResult:
@@ -395,6 +439,7 @@ def create_app(  # noqa: C901
     app.add_exception_handler(RateLimitExceeded, _rate_limit_handler)
     repository = climate_repository or build_default_climate_repository(resolve_climate_database_path())
     score_cache = _ScoreResponseCache(SCORE_CACHE_SIZE)
+    heatmap_field_cache = _HeatmapFieldCache(HEATMAP_FIELD_CACHE_SIZE, HEATMAP_FIELD_CACHE_TTL_SECONDS)
     # Serialize /score work per worker so repeated slider changes do not pile up CPU-bound builds.
     score_request_semaphore = asyncio.Semaphore(1)
     heatmap_request_semaphore = asyncio.Semaphore(1)
@@ -403,7 +448,15 @@ def create_app(  # noqa: C901
     # Pre-warm default scores so the page-load HTMX POST hits cache instead of paying the cold path.
     try:
         default_prefs = PreferenceInputs(**{f.name: f.value for f in DEFAULT_PREFERENCES})
-        score_cache.set(_score_cache_key(default_prefs), build_score_response(repository, default_prefs))
+        default_cache_key = _score_cache_key(default_prefs)
+        score_cache.set(
+            default_cache_key,
+            build_score_response(
+                repository,
+                default_prefs,
+                store_heatmap_field=lambda heatmap_field: heatmap_field_cache.set(default_cache_key, heatmap_field),
+            ),
+        )
         _log_runtime_memory("after_default_score_cache", repository)
         logger.info("startup default score cached", extra={"event": "startup_default_score", "outcome": "ok"})
     except ClimateDataError:
@@ -431,7 +484,11 @@ def create_app(  # noqa: C901
             async with score_request_semaphore:
                 queue_wait_ms = round((perf_counter() - queue_started) * 1000, 2)
                 raw_cache_result = await run_in_threadpool(
-                    _score_response_from_cache_or_repository, score_cache, repository, preferences
+                    _score_response_from_cache_or_repository,
+                    score_cache,
+                    heatmap_field_cache,
+                    repository,
+                    preferences,
                 )
             cache_result = _coerce_score_cache_result(raw_cache_result)
             logger.info(
@@ -466,8 +523,15 @@ def create_app(  # noqa: C901
         preferences: Annotated[PreferenceInputs, Depends(probe_preferences_dependency)],
     ) -> Response:
         try:
+            cache_key = _score_cache_key(preferences)
+            cached_heatmap_field = heatmap_field_cache.get(cache_key)
             async with heatmap_request_semaphore:
-                heatmap_png = await run_in_threadpool(build_heatmap_response, repository, preferences)
+                heatmap_png = await run_in_threadpool(
+                    build_heatmap_response,
+                    repository,
+                    preferences,
+                    cached_heatmap_field=cached_heatmap_field,
+                )
         except ClimateDataError as error:
             logger.exception(
                 "heatmap request failed",

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ from dataclasses import asdict
 from pathlib import Path
 from time import perf_counter
 from typing import TYPE_CHECKING, Annotated, NamedTuple, Protocol, cast
+from urllib.parse import urlencode
 
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
 from fastapi.exceptions import RequestValidationError
@@ -31,7 +32,7 @@ from backend.climate_repository import (
 from backend.config import DEFAULT_PREFERENCES, MAP_PROJECTION
 from backend.logging_config import configure_backend_logging
 from backend.runtime import resolve_climate_database_path
-from backend.score_service import ScoreResponse, build_score_response
+from backend.score_service import ScoreResponse, build_heatmap_response, build_score_response
 from backend.scoring import (
     ClimateCell,
     PreferenceInputs,
@@ -258,6 +259,18 @@ def _coerce_score_cache_result(result: _ScoreCacheResult | ScoreResponse) -> _Sc
     return _ScoreCacheResult(response=result, cache_hit=False)
 
 
+def _heatmap_url(preferences: PreferenceInputs) -> str:
+    return "/heatmap?" + urlencode(
+        {
+            "preferred_day_temperature": preferences.preferred_day_temperature,
+            "summer_heat_limit": preferences.summer_heat_limit,
+            "winter_cold_limit": preferences.winter_cold_limit,
+            "dryness_preference": preferences.dryness_preference,
+            "sunshine_preference": preferences.sunshine_preference,
+        }
+    )
+
+
 def _build_probe_response_from_repository(
     repository: _SupportsProbeRepository,
     lat: float,
@@ -362,7 +375,7 @@ def _attach_http_request_logging(app: FastAPI) -> None:
         return response
 
 
-def create_app(
+def create_app(  # noqa: C901
     climate_repository: ClimateRepository | None = None,
 ) -> FastAPI:
     """Create the FastAPI application.
@@ -384,6 +397,7 @@ def create_app(
     score_cache = _ScoreResponseCache(SCORE_CACHE_SIZE)
     # Serialize /score work per worker so repeated slider changes do not pile up CPU-bound builds.
     score_request_semaphore = asyncio.Semaphore(1)
+    heatmap_request_semaphore = asyncio.Semaphore(1)
     preload_repository(repository)
 
     # Pre-warm default scores so the page-load HTMX POST hits cache instead of paying the cold path.
@@ -411,7 +425,7 @@ def create_app(
 
     @app.post("/score")
     @limiter.limit("30/minute")
-    async def score(request: Request, preferences: Annotated[PreferenceInputs, Form()]) -> ScoreResponse:
+    async def score(request: Request, preferences: Annotated[PreferenceInputs, Form()]) -> dict[str, object]:
         try:
             queue_started = perf_counter()
             async with score_request_semaphore:
@@ -440,8 +454,37 @@ def create_app(
                 },
             )
             raise HTTPException(status_code=503, detail=str(error)) from error
-        else:
-            return cache_result.response
+        return {
+            "scores": cache_result.response["scores"],
+            "heatmap_url": _heatmap_url(preferences) if cache_result.response["scores"] else "",
+        }
+
+    @app.get("/heatmap")
+    @limiter.limit("30/minute")
+    async def heatmap(
+        request: Request,
+        preferences: Annotated[PreferenceInputs, Depends(probe_preferences_dependency)],
+    ) -> Response:
+        try:
+            async with heatmap_request_semaphore:
+                heatmap_png = await run_in_threadpool(build_heatmap_response, repository, preferences)
+        except ClimateDataError as error:
+            logger.exception(
+                "heatmap request failed",
+                extra={
+                    "event": "heatmap_request",
+                    "outcome": "error",
+                    "preferred_day_temperature": preferences.preferred_day_temperature,
+                    "summer_heat_limit": preferences.summer_heat_limit,
+                    "winter_cold_limit": preferences.winter_cold_limit,
+                    "dryness_preference": preferences.dryness_preference,
+                    "sunshine_preference": preferences.sunshine_preference,
+                },
+            )
+            raise HTTPException(status_code=503, detail=str(error)) from error
+        if not heatmap_png:
+            return Response(status_code=204)
+        return Response(content=heatmap_png, media_type="image/png")
 
     @app.get("/probe")
     @limiter.limit("120/minute")

--- a/backend/main.py
+++ b/backend/main.py
@@ -419,7 +419,7 @@ def _attach_http_request_logging(app: FastAPI) -> None:
         return response
 
 
-def create_app(  # noqa: C901
+def create_app(  # noqa: C901, PLR0915
     climate_repository: ClimateRepository | None = None,
 ) -> FastAPI:
     """Create the FastAPI application.

--- a/backend/score_service.py
+++ b/backend/score_service.py
@@ -97,7 +97,7 @@ def _empty_score_response(
     return EMPTY_SCORE_RESPONSE
 
 
-def _finalize_score_response(  # noqa: PLR0913
+def _finalize_score_response(
     timings: ScoreTimings,
     *,
     preferences: PreferenceInputs,

--- a/backend/score_service.py
+++ b/backend/score_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from time import perf_counter
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, TypedDict, cast
 
 import numpy as np
 
@@ -19,6 +19,8 @@ from backend.scoring import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from numpy.typing import NDArray
 
     from backend.climate_repository import ClimateRepository
@@ -51,6 +53,15 @@ class ScoreContext:
 
     climate_cell_count: int
     city_count: int
+
+
+@dataclass(slots=True)
+class HeatmapField:
+    """Reusable normalized score field for one preference tuple."""
+
+    normalized_scores: NDArray[np.float32] | list[CellScorePoint]
+    latitudes: NDArray[np.float32] | None = None
+    longitudes: NDArray[np.float32] | None = None
 
 
 class ScoreResponse(TypedDict):
@@ -299,7 +310,12 @@ def _log_score_timings(  # noqa: PLR0913
     )
 
 
-def build_score_response(repository: ClimateRepository, preferences: PreferenceInputs) -> ScoreResponse:
+def build_score_response(
+    repository: ClimateRepository,
+    preferences: PreferenceInputs,
+    *,
+    store_heatmap_field: Callable[[HeatmapField], None] | None = None,
+) -> ScoreResponse:
     """Score all available climate cells and shape the `/score` API payload.
 
     The route keeps FastAPI concerns only; this function owns the application-level
@@ -310,9 +326,21 @@ def build_score_response(repository: ClimateRepository, preferences: PreferenceI
     timings = ScoreTimings()
 
     if hasattr(repository, "get_climate_matrix") and hasattr(repository, "get_indexed_cities"):
-        return _build_score_response_from_matrix(repository, preferences, request_started, timings)
+        return _build_score_response_from_matrix(
+            repository,
+            preferences,
+            request_started,
+            timings,
+            store_heatmap_field=store_heatmap_field,
+        )
 
-    return _build_score_response_from_cells(repository, preferences, request_started, timings)
+    return _build_score_response_from_cells(
+        repository,
+        preferences,
+        request_started,
+        timings,
+        store_heatmap_field=store_heatmap_field,
+    )
 
 
 def _build_score_response_from_matrix(
@@ -320,6 +348,8 @@ def _build_score_response_from_matrix(
     preferences: PreferenceInputs,
     request_started: float,
     timings: ScoreTimings,
+    *,
+    store_heatmap_field: Callable[[HeatmapField], None] | None,
 ) -> ScoreResponse:
     cells_started = perf_counter()
     climate_matrix = repository.get_climate_matrix()
@@ -356,6 +386,14 @@ def _build_score_response_from_matrix(
     normalize_started = perf_counter()
     normalized_scores = normalize_score_array(raw_scores)
     timings.normalize_ms = _elapsed_ms(normalize_started)
+    if store_heatmap_field is not None:
+        store_heatmap_field(
+            HeatmapField(
+                normalized_scores=normalized_scores,
+                latitudes=climate_matrix.latitudes,
+                longitudes=climate_matrix.longitudes,
+            )
+        )
 
     ranking_started = perf_counter()
     ranking_catalog = _filter_ranking_catalog(indexed_cities)
@@ -380,6 +418,8 @@ def _build_score_response_from_cells(
     preferences: PreferenceInputs,
     request_started: float,
     timings: ScoreTimings,
+    *,
+    store_heatmap_field: Callable[[HeatmapField], None] | None,
 ) -> ScoreResponse:
 
     cells_started = perf_counter()
@@ -423,6 +463,8 @@ def _build_score_response_from_cells(
         for point in raw_scores
     ]
     timings.normalize_ms = _elapsed_ms(normalize_started)
+    if store_heatmap_field is not None:
+        store_heatmap_field(HeatmapField(normalized_scores=normalized_scores))
 
     ranking_started = perf_counter()
     ranking_catalog = _filter_city_candidates(cities)
@@ -440,8 +482,16 @@ def _build_score_response_from_cells(
     )
 
 
-def build_heatmap_response(repository: ClimateRepository, preferences: PreferenceInputs) -> bytes:
+def build_heatmap_response(
+    repository: ClimateRepository,
+    preferences: PreferenceInputs,
+    *,
+    cached_heatmap_field: HeatmapField | None = None,
+) -> bytes:
     """Build the `/heatmap` PNG payload for one user preference request."""
+    if cached_heatmap_field is not None:
+        return _render_heatmap_from_field(repository, cached_heatmap_field)
+
     if hasattr(repository, "get_climate_matrix"):
         return _build_heatmap_response_from_matrix(repository, preferences)
 
@@ -487,3 +537,19 @@ def _build_heatmap_response_from_cells(repository: ClimateRepository, preference
         for point in raw_scores
     ]
     return render_heatmap_png(normalized_scores)
+
+
+def _render_heatmap_from_field(repository: ClimateRepository, heatmap_field: HeatmapField) -> bytes:
+    if heatmap_field.latitudes is not None and heatmap_field.longitudes is not None:
+        if hasattr(repository, "get_heatmap_projection"):
+            return render_heatmap_png_from_projection(
+                repository.get_heatmap_projection(),
+                cast("NDArray[np.float32]", heatmap_field.normalized_scores),
+            )
+        return render_heatmap_png_from_arrays(
+            heatmap_field.latitudes,
+            heatmap_field.longitudes,
+            cast("NDArray[np.float32]", heatmap_field.normalized_scores),
+        )
+
+    return render_heatmap_png(cast("list[CellScorePoint]", heatmap_field.normalized_scores))

--- a/backend/score_service.py
+++ b/backend/score_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import logging
 from dataclasses import dataclass
 from time import perf_counter
@@ -58,10 +57,9 @@ class ScoreResponse(TypedDict):
     """Backend response contract for one scored user preference request."""
 
     scores: list[CityScorePoint]
-    heatmap: str
 
 
-EMPTY_SCORE_RESPONSE: ScoreResponse = {"scores": [], "heatmap": ""}
+EMPTY_SCORE_RESPONSE: ScoreResponse = {"scores": []}
 
 
 def _elapsed_ms(start_time: float) -> float:
@@ -95,14 +93,7 @@ def _finalize_score_response(  # noqa: PLR0913
     request_started: float,
     context: ScoreContext,
     ranked_cities: list[CityScorePoint],
-    heatmap_png: bytes,
 ) -> ScoreResponse:
-    response_started = perf_counter()
-    response: ScoreResponse = {
-        "scores": ranked_cities,
-        "heatmap": "data:image/png;base64," + base64.b64encode(heatmap_png).decode(),
-    }
-    timings.response_ms = _elapsed_ms(response_started)
     timings.total_ms = _elapsed_ms(request_started)
     _log_score_timings(
         timings,
@@ -112,7 +103,7 @@ def _finalize_score_response(  # noqa: PLR0913
         ranked_city_count=len(ranked_cities),
         outcome="ok",
     )
-    return response
+    return {"scores": ranked_cities}
 
 
 def _filter_ranking_catalog(city_catalog: CityRankingCache) -> CityRankingCache:
@@ -375,24 +366,12 @@ def _build_score_response_from_matrix(
     top_cities = _rescore_city_points_from_cache(ranking_catalog, top_cities, raw_scores)
     timings.ranking_ms = _elapsed_ms(ranking_started)
 
-    heatmap_started = perf_counter()
-    # Some injected repositories only support the cached matrix/ranking fast path.
-    if hasattr(repository, "get_heatmap_projection"):
-        heatmap_png = render_heatmap_png_from_projection(repository.get_heatmap_projection(), normalized_scores)
-    else:
-        heatmap_png = render_heatmap_png_from_arrays(
-            climate_matrix.latitudes,
-            climate_matrix.longitudes,
-            normalized_scores,
-        )
-    timings.heatmap_ms = _elapsed_ms(heatmap_started)
     return _finalize_score_response(
         timings,
         preferences=preferences,
         request_started=request_started,
         context=context,
         ranked_cities=top_cities,
-        heatmap_png=heatmap_png,
     )
 
 
@@ -452,14 +431,59 @@ def _build_score_response_from_cells(
     top_cities = _rescore_city_points_from_cells(ranking_catalog, top_cities, raw_scores)
     timings.ranking_ms = _elapsed_ms(ranking_started)
 
-    heatmap_started = perf_counter()
-    heatmap_png = render_heatmap_png(normalized_scores)
-    timings.heatmap_ms = _elapsed_ms(heatmap_started)
     return _finalize_score_response(
         timings,
         preferences=preferences,
         request_started=request_started,
         context=context,
         ranked_cities=top_cities,
-        heatmap_png=heatmap_png,
     )
+
+
+def build_heatmap_response(repository: ClimateRepository, preferences: PreferenceInputs) -> bytes:
+    """Build the `/heatmap` PNG payload for one user preference request."""
+    if hasattr(repository, "get_climate_matrix"):
+        return _build_heatmap_response_from_matrix(repository, preferences)
+
+    return _build_heatmap_response_from_cells(repository, preferences)
+
+
+def _build_heatmap_response_from_matrix(repository: ClimateRepository, preferences: PreferenceInputs) -> bytes:
+    climate_matrix = repository.get_climate_matrix()
+    raw_scores = score_climate_matrix(climate_matrix, preferences)
+
+    if raw_scores.size == 0:
+        return b""
+
+    max_score = float(raw_scores.max())
+    if max_score == 0.0:
+        return b""
+
+    normalized_scores = normalize_score_array(raw_scores)
+
+    # Some injected repositories only support the cached matrix/ranking fast path.
+    if hasattr(repository, "get_heatmap_projection"):
+        return render_heatmap_png_from_projection(repository.get_heatmap_projection(), normalized_scores)
+
+    return render_heatmap_png_from_arrays(
+        climate_matrix.latitudes,
+        climate_matrix.longitudes,
+        normalized_scores,
+    )
+
+
+def _build_heatmap_response_from_cells(repository: ClimateRepository, preferences: PreferenceInputs) -> bytes:
+    raw_scores = score_climate_cells(repository.list_cells(), preferences)
+
+    if not raw_scores:
+        return b""
+
+    max_score = max(point["score"] for point in raw_scores)
+    if max_score == 0:
+        return b""
+
+    normalized_scores: list[CellScorePoint] = [
+        {"lat": point["lat"], "lon": point["lon"], "score": round(point["score"] / max_score, 4)}
+        for point in raw_scores
+    ]
+    return render_heatmap_png(normalized_scores)

--- a/frontend/static/map.js
+++ b/frontend/static/map.js
@@ -1,14 +1,14 @@
 "use strict";
 
-function applyScoreResponse(scores, heatmap) {
-  applyHeatmap(heatmap);
+function applyScoreResponse(scores, heatmapUrl) {
+  applyHeatmap(heatmapUrl || EMPTY_IMAGE);
   const markers = visibleScoresForList(scores);
   if (markers.length > 0) {
     applyMarkers(markers);
   } else {
     clearMarkers();
   }
-  setMapStatus(heatmap !== EMPTY_IMAGE ? `${scores.length} top matches shown.` : "No matches found.");
+  setMapStatus(heatmapUrl ? `${scores.length} top matches shown.` : "No matches found.");
 }
 
 function initializeMap() {
@@ -89,16 +89,16 @@ function initializeMap() {
 
     if (!pendingResponse) return;
 
-    const { scores, heatmap } = pendingResponse;
-    applyScoreResponse(scores ?? [], heatmap);
+    const { scores, heatmap_url } = pendingResponse;
+    applyScoreResponse(scores ?? [], heatmap_url);
     pendingResponse = null;
   });
 }
 
 // Public handoff used by `app.js` after a successful `/score` HTMX response.
-// Expects the raw backend payload and tolerates empty-result heatmaps.
+// Expects the raw backend payload and lets the map load the heatmap separately.
 window.renderScores = function renderScores(response) {
-  const { scores, heatmap } = response;
+  const { scores, heatmap_url } = response;
   continentVisibleCounts.clear();
   currentScores = scores ?? [];
 
@@ -107,9 +107,9 @@ window.renderScores = function renderScores(response) {
   if (!map) return;
 
   if (mapLoaded) {
-    applyScoreResponse(currentScores, heatmap || EMPTY_IMAGE);
+    applyScoreResponse(currentScores, heatmap_url);
   } else {
-    pendingResponse = { ...response, heatmap: heatmap || EMPTY_IMAGE };
+    pendingResponse = response;
   }
 };
 

--- a/tests/test_app_frontend.py
+++ b/tests/test_app_frontend.py
@@ -164,7 +164,7 @@ def test_app_runtime_shows_generic_error_and_clears_it_after_success() -> None:
             if (renderCalls.length !== 0) throw new Error("failed request should not render scores");
 
             triggerBody("htmx:beforeRequest", { elt: form });
-            triggerBody("htmx:afterRequest", { elt: form, xhr: { status: 200, responseText: '{"scores":[],"heatmap":""}' } });
+            triggerBody("htmx:afterRequest", { elt: form, xhr: { status: 200, responseText: '{"scores":[],"heatmap_url":""}' } });
 
             if (!errorIndicator.hidden) throw new Error("successful request should clear error indicator");
             if (!loadingIndicator.hidden) throw new Error("loading indicator should stay hidden after success");

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 
+from backend import score_service as backend_score_service
 from backend.cities import GRID_DEGREES, CityCandidate, CityRankingCache, continent_of
 from backend.climate_repository import ClimateDataError, StubClimateRepository
 from backend.config import DEFAULT_PREFERENCES, MAP_PROJECTION, PREFERENCE_FIELD_NAMES
@@ -643,10 +644,15 @@ def test_score_endpoint_reuses_cached_response_for_identical_preferences() -> No
     call_count = 0
     original_builder = backend_main.build_score_response
 
-    def counted_builder(repository: StubClimateRepository, preferences: PreferenceInputs) -> ScoreResponse:
+    def counted_builder(
+        repository: StubClimateRepository,
+        preferences: PreferenceInputs,
+        *,
+        store_heatmap_field: Callable[[backend_score_service.HeatmapField], None] | None = None,
+    ) -> ScoreResponse:
         nonlocal call_count
         call_count += 1
-        return original_builder(repository, preferences)
+        return original_builder(repository, preferences, store_heatmap_field=store_heatmap_field)
 
     backend_main.__dict__["build_score_response"] = counted_builder
     cached_client = TestClient(create_app(climate_repository=StubClimateRepository()))
@@ -666,10 +672,15 @@ def test_score_endpoint_uses_prewarmed_default_preferences_cache() -> None:
     call_count = 0
     original_builder = backend_main.build_score_response
 
-    def counted_builder(repository: StubClimateRepository, preferences: PreferenceInputs) -> ScoreResponse:
+    def counted_builder(
+        repository: StubClimateRepository,
+        preferences: PreferenceInputs,
+        *,
+        store_heatmap_field: Callable[[backend_score_service.HeatmapField], None] | None = None,
+    ) -> ScoreResponse:
         nonlocal call_count
         call_count += 1
-        return original_builder(repository, preferences)
+        return original_builder(repository, preferences, store_heatmap_field=store_heatmap_field)
 
     backend_main.__dict__["build_score_response"] = counted_builder
 
@@ -731,10 +742,15 @@ def test_score_endpoint_evicts_oldest_cached_preferences_after_cache_limit() -> 
     call_count = 0
     original_builder = backend_main.build_score_response
 
-    def counted_builder(repository: StubClimateRepository, preferences: PreferenceInputs) -> ScoreResponse:
+    def counted_builder(
+        repository: StubClimateRepository,
+        preferences: PreferenceInputs,
+        *,
+        store_heatmap_field: Callable[[backend_score_service.HeatmapField], None] | None = None,
+    ) -> ScoreResponse:
         nonlocal call_count
         call_count += 1
-        return original_builder(repository, preferences)
+        return original_builder(repository, preferences, store_heatmap_field=store_heatmap_field)
 
     backend_main.__dict__["build_score_response"] = counted_builder
     cached_client = TestClient(create_app(climate_repository=StubClimateRepository()))
@@ -756,6 +772,34 @@ def test_score_endpoint_evicts_oldest_cached_preferences_after_cache_limit() -> 
     assert repeated_first.status_code == 200
     assert newest_repeat.status_code == 200
     assert call_count == 19  # 1 pre-warm + 17 unique keys + 1 recompute after LRU eviction
+
+
+def test_heatmap_endpoint_reuses_score_field_from_prior_score_request(monkeypatch: MonkeyPatch) -> None:
+    score_calls = 0
+    original_score_matrix = backend_score_service.score_climate_matrix
+    cached_client = TestClient(create_app(climate_repository=StubClimateRepository()))
+    form_data = {
+        "preferred_day_temperature": "24",
+        "summer_heat_limit": "37",
+        "winter_cold_limit": "10",
+        "dryness_preference": "15",
+        "sunshine_preference": "85",
+    }
+
+    def counted_score_matrix(climate_matrix: ClimateMatrix, preferences: PreferenceInputs) -> np.ndarray:
+        nonlocal score_calls
+        score_calls += 1
+        return original_score_matrix(climate_matrix, preferences)
+
+    monkeypatch.setattr(backend_score_service, "score_climate_matrix", counted_score_matrix)
+
+    score_response = cached_client.post("/score", data=form_data)
+    heatmap_response = cached_client.get("/heatmap", params=form_data)
+
+    assert score_response.status_code == 200
+    assert heatmap_response.status_code == 200
+    assert heatmap_response.headers["content-type"] == "image/png"
+    assert score_calls == 1
 
 
 def test_score_response_cache_deduplicates_concurrent_identical_misses() -> None:

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -458,7 +458,7 @@ def test_score_endpoint_accepts_form_encoded_preferences() -> None:
     payload = response.json()
 
     assert isinstance(payload, dict)
-    assert set(payload) == {"scores", "heatmap"}
+    assert set(payload) == {"scores", "heatmap_url"}
 
     scores = payload["scores"]
     assert isinstance(scores, list)
@@ -497,8 +497,7 @@ def test_score_endpoint_accepts_form_encoded_preferences() -> None:
         continent_counts[continent] = continent_counts.get(continent, 0) + 1
     assert continent_counts
     assert all(count <= 30 for count in continent_counts.values())
-    # Heatmap is a PNG data URL
-    assert payload["heatmap"].startswith("data:image/png;base64,")
+    assert payload["heatmap_url"].startswith("/heatmap?")
 
 
 def test_score_endpoint_offloads_scoring_to_threadpool(monkeypatch: MonkeyPatch) -> None:
@@ -541,7 +540,7 @@ async def test_score_endpoint_serializes_concurrent_requests_per_worker() -> Non
         else:
             second_entered.set()
 
-        return {"scores": [], "heatmap": ""}
+        return {"scores": []}
 
     backend_main.__dict__["_score_response_from_cache_or_repository"] = slow_builder
 
@@ -590,7 +589,7 @@ async def test_score_endpoint_releases_semaphore_after_failed_request() -> None:
             raise ClimateDataError(msg)
 
         second_entered.set()
-        return {"scores": [], "heatmap": ""}
+        return {"scores": []}
 
     backend_main.__dict__["_score_response_from_cache_or_repository"] = flaky_builder
 
@@ -625,8 +624,7 @@ def test_score_endpoint_uses_gzip_when_requested() -> None:
 
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/json")
-    assert response.headers.get("content-encoding") == "gzip"
-    assert "Accept-Encoding" in response.headers.get("vary", "")
+    assert response.headers.get("content-encoding") is None
 
 
 def test_score_endpoint_is_deterministic_for_the_same_preferences() -> None:
@@ -638,7 +636,7 @@ def test_score_endpoint_is_deterministic_for_the_same_preferences() -> None:
     assert first_response.status_code == 200
     assert second_response.status_code == 200
     assert first_response.json()["scores"] == second_response.json()["scores"]
-    assert first_response.json()["heatmap"] == second_response.json()["heatmap"]
+    assert first_response.json()["heatmap_url"] == second_response.json()["heatmap_url"]
 
 
 def test_score_endpoint_reuses_cached_response_for_identical_preferences() -> None:
@@ -773,7 +771,7 @@ def test_score_response_cache_deduplicates_concurrent_identical_misses() -> None
         build_count += 1
         build_started.set()
         time.sleep(0.05)
-        return {"scores": [], "heatmap": "cached"}
+        return {"scores": []}
 
     def worker() -> None:
         results.append(cache.get_or_set(key, build))
@@ -787,7 +785,7 @@ def test_score_response_cache_deduplicates_concurrent_identical_misses() -> None
         assert not thread.is_alive()
 
     assert build_count == 1
-    assert results == [{"scores": [], "heatmap": "cached"}, {"scores": [], "heatmap": "cached"}]
+    assert results == [{"scores": []}, {"scores": []}]
 
 
 def test_score_response_cache_recovers_after_failing_inflight_build() -> None:
@@ -807,7 +805,7 @@ def test_score_response_cache_recovers_after_failing_inflight_build() -> None:
             time.sleep(0.05)
             msg = "boom"
             raise RuntimeError(msg)
-        return {"scores": [], "heatmap": "recovered"}
+        return {"scores": []}
 
     def worker() -> None:
         try:
@@ -824,9 +822,9 @@ def test_score_response_cache_recovers_after_failing_inflight_build() -> None:
         assert not thread.is_alive()
 
     assert failures == ["boom"]
-    assert successes == [{"scores": [], "heatmap": "recovered"}]
+    assert successes == [{"scores": []}]
     assert call_count == 2
-    assert cache.get_or_set(key, flaky_build) == {"scores": [], "heatmap": "recovered"}
+    assert cache.get_or_set(key, flaky_build) == {"scores": []}
     assert call_count == 2
 
 

--- a/tests/test_climate_repository.py
+++ b/tests/test_climate_repository.py
@@ -454,7 +454,7 @@ def test_create_app_preload_is_best_effort_for_data_errors() -> None:
     assert app.title == "Pogodapp"
 
 
-def test_create_app_preload_warms_caches_without_rebuilding_on_first_request() -> None:
+def test_create_app_preload_warms_caches_without_rebuilding_on_first_score_request() -> None:
     class CountingRepository:
         def __init__(self) -> None:
             self.matrix_builds = 0
@@ -512,6 +512,70 @@ def test_create_app_preload_warms_caches_without_rebuilding_on_first_request() -
     )
 
     assert response.status_code == 200
+    assert repository.matrix_builds == 1
+    assert repository.city_cache_builds == 1
+    assert repository.heatmap_builds == 1
+
+
+def test_heatmap_endpoint_uses_preloaded_projection_without_rebuilding() -> None:
+    class CountingRepository:
+        def __init__(self) -> None:
+            self.matrix_builds = 0
+            self.city_cache_builds = 0
+            self.heatmap_builds = 0
+            self._matrix: ClimateMatrix | None = None
+            self._cities: CityRankingCache | None = None
+            self._projection: HeatmapProjection | None = None
+
+        def list_cells(self) -> tuple[ClimateCell, ...]:
+            return ()
+
+        def list_cities(self) -> tuple[CityCandidate, ...]:
+            return ()
+
+        def get_climate_matrix(self) -> ClimateMatrix:
+            if self._matrix is None:
+                self.matrix_builds += 1
+                self._matrix = ClimateMatrix.from_cells(
+                    (
+                        ClimateCell(
+                            lat=1.0,
+                            lon=2.0,
+                            temperature_c=(22.0,) * 12,
+                            temperature_min_c=(22.0,) * 12,
+                            temperature_max_c=(22.0,) * 12,
+                            precipitation_mm=(0.0,) * 12,
+                            cloud_cover_pct=(15,) * 12,
+                        ),
+                    )
+                )
+            return self._matrix
+
+        def get_indexed_cities(self) -> CityRankingCache:
+            if self._cities is None:
+                self.city_cache_builds += 1
+                self._cities = CityRankingCache.from_cities((), np.array([], dtype=np.int32))
+            return self._cities
+
+        def get_heatmap_projection(self) -> HeatmapProjection:
+            if self._projection is None:
+                self.heatmap_builds += 1
+                climate_matrix = self.get_climate_matrix()
+                self._projection = HeatmapProjection.from_coordinates(
+                    climate_matrix.latitudes, climate_matrix.longitudes
+                )
+            return self._projection
+
+    repository = CountingRepository()
+    client = TestClient(create_app(climate_repository=cast("ClimateRepository", repository)))
+
+    response = client.get(
+        "/heatmap",
+        params=default_form_data(),
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
     assert repository.matrix_builds == 1
     assert repository.city_cache_builds == 1
     assert repository.heatmap_builds == 1

--- a/tests/test_score_service.py
+++ b/tests/test_score_service.py
@@ -8,7 +8,7 @@ import numpy as np
 from backend.cities import CityCandidate, CityRankingCache, CityScorePoint
 from backend.climate_repository import StubClimateRepository
 from backend.logging_config import configure_backend_logging
-from backend.score_service import _deduplicate_city_points, build_score_response
+from backend.score_service import _deduplicate_city_points, build_heatmap_response, build_score_response
 from backend.scoring import ClimateCell, ClimateMatrix, PreferenceInputs
 
 if TYPE_CHECKING:
@@ -50,7 +50,6 @@ def test_build_score_response_logs_step_timings(caplog: LogCaptureFixture) -> No
 
     assert response["scores"]
     assert "markers" not in response
-    assert response["heatmap"].startswith("data:image/png;base64,")
     assert caplog.records
     record = caplog.records[-1]
     assert record.message == "score request finished"
@@ -62,7 +61,7 @@ def test_build_score_response_logs_step_timings(caplog: LogCaptureFixture) -> No
     assert cast("float", record.__dict__["scoring_ms"]) >= 0
     assert cast("float", record.__dict__["normalize_ms"]) >= 0
     assert cast("float", record.__dict__["ranking_ms"]) >= 0
-    assert cast("float", record.__dict__["heatmap_ms"]) >= 0
+    assert record.__dict__["heatmap_ms"] == 0.0
     assert cast("float", record.__dict__["response_ms"]) >= 0
     assert record.__dict__["preferred_day_temperature"] == preferences.preferred_day_temperature
     assert record.__dict__["summer_heat_limit"] == preferences.summer_heat_limit
@@ -98,7 +97,7 @@ def test_build_score_response_returns_empty_payload_for_empty_matrix() -> None:
         make_preferences(),
     )
 
-    assert response == {"scores": [], "heatmap": ""}
+    assert response == {"scores": []}
 
 
 def test_build_score_response_returns_empty_payload_for_all_zero_matrix_scores(monkeypatch: MonkeyPatch) -> None:
@@ -134,10 +133,10 @@ def test_build_score_response_returns_empty_payload_for_all_zero_matrix_scores(m
         make_preferences(),
     )
 
-    assert response == {"scores": [], "heatmap": ""}
+    assert response == {"scores": []}
 
 
-def test_build_score_response_falls_back_to_array_heatmap_path_when_projection_cache_is_absent() -> None:
+def test_build_heatmap_response_falls_back_to_array_heatmap_path_when_projection_cache_is_absent() -> None:
     class MatrixOnlyRepository:
         def list_cells(self) -> tuple[ClimateCell, ...]:
             return ()
@@ -163,13 +162,12 @@ def test_build_score_response_falls_back_to_array_heatmap_path_when_projection_c
         def get_indexed_cities(self) -> CityRankingCache:
             return CityRankingCache.from_cities((), np.array([], dtype=np.int32))
 
-    response = build_score_response(
+    response = build_heatmap_response(
         cast("ClimateRepository", MatrixOnlyRepository()),
         make_preferences(),
     )
 
-    assert response["scores"] == []
-    assert response["heatmap"].startswith("data:image/png;base64,")
+    assert response.startswith(b"\x89PNG\r\n\x1a\n")
 
 
 def test_deduplicate_city_points_removes_duplicate_substituted_cities() -> None:


### PR DESCRIPTION
## Summary
- make `POST /score` return ranked results immediately with a `heatmap_url` instead of embedding the heatmap image in the JSON payload
- add `GET /heatmap` so the map can load the PNG separately from the ranked-result response
- keep the single-screen HTMX flow while removing heatmap generation from the ranked-result critical path

Closes #71 

## Why
Stress-test traces from #74 showed that warm `/score` misses are still expensive and that heatmap generation is a large independent chunk of miss latency. This change decouples ranked-result latency from heatmap render completion without changing the one-page interaction model.

## Testing
- uv run pytest -q