### PR TITLE
Shrink runtime cloud and heatmap types

### DIFF
--- a/backend/climate_repository.py
+++ b/backend/climate_repository.py
@@ -205,8 +205,8 @@ class DuckDbClimateRepository:
             coldest_month_lows_c = np.asarray(columns["coldest_month_lows_c"], dtype=FLOAT32_DTYPE)
             median_precipitation_mm = np.asarray(columns["median_precipitation_mm"], dtype=FLOAT32_DTYPE)
             wettest_precipitation_mm = np.asarray(columns["wettest_precipitation_mm"], dtype=FLOAT32_DTYPE)
-            average_cloud_cover_pct = np.asarray(columns["average_cloud_cover_pct"], dtype=FLOAT32_DTYPE)
-            gloomiest_cloud_cover_pct = np.asarray(columns["gloomiest_cloud_cover_pct"], dtype=FLOAT32_DTYPE)
+            average_cloud_cover_pct = np.asarray(columns["average_cloud_cover_pct"], dtype=UINT8_DTYPE)
+            gloomiest_cloud_cover_pct = np.asarray(columns["gloomiest_cloud_cover_pct"], dtype=UINT8_DTYPE)
         except (KeyError, TypeError, ValueError) as error:
             msg = f"Failed to map climate data from {self.database_path} into climate rows: {error}"
             raise ClimateDataError(msg) from error

--- a/backend/heatmap.py
+++ b/backend/heatmap.py
@@ -51,8 +51,8 @@ class HeatmapProjection:
     """Cached raster coordinates for one fixed climate grid."""
 
     score_indexes: NDArray[np.int32]
-    xs: NDArray[np.int32]
-    ys: NDArray[np.int32]
+    xs: NDArray[np.uint16]
+    ys: NDArray[np.uint16]
     # Pre-dilated land mask: MaxFilter(7) is grid-fixed, not score-dependent.
     land_mask: NDArray[np.bool_]
 
@@ -64,9 +64,9 @@ class HeatmapProjection:
         valid_latitudes = latitudes[valid]
         valid_longitudes = longitudes[valid]
 
-        xs = ((valid_longitudes + 180.0) / 360.0 * WIDTH).astype(np.int32)
+        xs = ((valid_longitudes + 180.0) / 360.0 * WIDTH).astype(np.uint16)
         y_merc = np.log(np.tan(np.pi / 4 + np.radians(valid_latitudes) / 2))
-        ys = ((_Y_MAX - y_merc) / (2 * _Y_MAX) * HEIGHT).astype(np.int32)
+        ys = ((_Y_MAX - y_merc) / (2 * _Y_MAX) * HEIGHT).astype(np.uint16)
 
         in_bounds = (xs >= 0) & (xs < WIDTH) & (ys >= 0) & (ys < HEIGHT)
         final_xs = xs[in_bounds]

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -111,8 +111,8 @@ class ClimateMatrix:
     coldest_month_lows_c: NDArray[np.float32] = field(default_factory=lambda: np.array([], dtype=np.float32))
     median_precipitation_mm: NDArray[np.float32] = field(default_factory=lambda: np.array([], dtype=np.float32))
     wettest_precipitation_mm: NDArray[np.float32] = field(default_factory=lambda: np.array([], dtype=np.float32))
-    average_cloud_cover_pct: NDArray[np.float32] = field(default_factory=lambda: np.array([], dtype=np.float32))
-    gloomiest_cloud_cover_pct: NDArray[np.float32] = field(default_factory=lambda: np.array([], dtype=np.float32))
+    average_cloud_cover_pct: NDArray[np.uint8] = field(default_factory=lambda: np.array([], dtype=np.uint8))
+    gloomiest_cloud_cover_pct: NDArray[np.uint8] = field(default_factory=lambda: np.array([], dtype=np.uint8))
 
     def __post_init__(self) -> None:
         """Reject malformed matrix shapes before they reach the scorer."""
@@ -153,12 +153,12 @@ class ClimateMatrix:
             )
             self._ensure_derived_vector(
                 "average_cloud_cover_pct",
-                np.rint(np.mean(cloud_cover_pct.astype(np.float32), axis=1)).astype(np.float32, copy=False),
+                np.rint(np.mean(cloud_cover_pct.astype(np.float32), axis=1)).astype(np.uint8, copy=False),
                 cell_count,
             )
             self._ensure_derived_vector(
                 "gloomiest_cloud_cover_pct",
-                np.max(cloud_cover_pct, axis=1).astype(np.float32, copy=False),
+                np.max(cloud_cover_pct, axis=1).astype(np.uint8, copy=False),
                 cell_count,
             )
             return
@@ -227,7 +227,7 @@ class ClimateMatrix:
                 msg = f"{attribute} must align with latitudes"
                 raise ValueError(msg)
 
-    def _ensure_derived_vector(self, attribute: str, derived: NDArray[np.float32], cell_count: int) -> None:
+    def _ensure_derived_vector(self, attribute: str, derived: NDArray[np.generic], cell_count: int) -> None:
         current = getattr(self, attribute)
         if current.shape == (0,):
             object.__setattr__(self, attribute, derived)

--- a/tests/test_climate_repository.py
+++ b/tests/test_climate_repository.py
@@ -135,8 +135,8 @@ def test_duckdb_climate_repository_loads_compact_matrix_with_expected_order_and_
     assert matrix.coldest_month_lows_c.dtype == np.float32
     assert matrix.median_precipitation_mm.dtype == np.float32
     assert matrix.wettest_precipitation_mm.dtype == np.float32
-    assert matrix.average_cloud_cover_pct.dtype == np.float32
-    assert matrix.gloomiest_cloud_cover_pct.dtype == np.float32
+    assert matrix.average_cloud_cover_pct.dtype == np.uint8
+    assert matrix.gloomiest_cloud_cover_pct.dtype == np.uint8
     assert matrix.typical_highs_c.tolist() == [8.5]
     assert matrix.hottest_month_highs_c.tolist() == [14.0]
     assert matrix.coldest_month_lows_c.tolist() == [-1.0]


### PR DESCRIPTION
## Summary
- store derived cloud-cover vectors in the runtime climate matrix as `uint8` instead of `float32`
- store cached heatmap projection pixel coordinates as `uint16` instead of `int32`
- keep the score math unchanged while shrinking integer-like runtime representations

## Why
This is the first low-risk `#75` pass. The hot runtime path already uses `float32` in most numeric arrays, so the immediate safe win is to move obviously discrete runtime values to integer dtypes before considering larger representation changes.

## Testing
- uv run pytest -q