### PR TITLE
Speed up cold /score requests and ranking

### DIFF
--- a/backend/cities.py
+++ b/backend/cities.py
@@ -352,7 +352,10 @@ class CityRankingCache:
     climate_indexes: NDArray[np.int32]
     latitude_radians: NDArray[np.float32]
     longitude_radians: NDArray[np.float32]
+    sine_latitudes: NDArray[np.float32]
     cosine_latitudes: NDArray[np.float32]
+    sine_longitudes: NDArray[np.float32]
+    cosine_longitudes: NDArray[np.float32]
     flags: tuple[str, ...]
 
     def __post_init__(self) -> None:
@@ -373,6 +376,18 @@ class CityRankingCache:
 
         if self.cosine_latitudes.shape != (city_count,):
             msg = "cosine_latitudes must align with cities"
+            raise ValueError(msg)
+
+        if self.sine_latitudes.shape != (city_count,):
+            msg = "sine_latitudes must align with cities"
+            raise ValueError(msg)
+
+        if self.sine_longitudes.shape != (city_count,):
+            msg = "sine_longitudes must align with cities"
+            raise ValueError(msg)
+
+        if self.cosine_longitudes.shape != (city_count,):
+            msg = "cosine_longitudes must align with cities"
             raise ValueError(msg)
 
         if len(self.flags) != city_count:
@@ -399,7 +414,10 @@ class CityRankingCache:
             climate_indexes=climate_indexes,
             latitude_radians=latitude_radians,
             longitude_radians=longitude_radians,
+            sine_latitudes=np.sin(latitude_radians).astype(np.float32, copy=False),
             cosine_latitudes=np.cos(latitude_radians).astype(np.float32, copy=False),
+            sine_longitudes=np.sin(longitude_radians).astype(np.float32, copy=False),
+            cosine_longitudes=np.cos(longitude_radians).astype(np.float32, copy=False),
             flags=tuple(country_flag(city.country_code) for city in cities),
         )
 
@@ -540,15 +558,20 @@ def _haversine_distance_vector_km(
     winner_index: int,
 ) -> NDArray[np.float32]:
     """Vectorized winner-to-all distances for one diversity-penalty update."""
-    latitude_radians = city_catalog.latitude_radians[winner_index]
-    longitude_radians = city_catalog.longitude_radians[winner_index]
+    sine_latitude = city_catalog.sine_latitudes[winner_index]
     cosine_latitude = city_catalog.cosine_latitudes[winner_index]
-    delta_lat = city_catalog.latitude_radians - latitude_radians
-    delta_lon = city_catalog.longitude_radians - longitude_radians
-    half_chord = (
-        np.sin(delta_lat / 2.0) ** 2 + cosine_latitude * city_catalog.cosine_latitudes * np.sin(delta_lon / 2.0) ** 2
+    cosine_delta_longitude = (
+        city_catalog.cosine_longitudes[winner_index] * city_catalog.cosine_longitudes
+        + city_catalog.sine_longitudes[winner_index] * city_catalog.sine_longitudes
     )
-    return (2.0 * EARTH_RADIUS_KM * np.arcsin(np.sqrt(half_chord))).astype(np.float32, copy=False)
+    central_angle_cosine = (
+        sine_latitude * city_catalog.sine_latitudes
+        + cosine_latitude * city_catalog.cosine_latitudes * cosine_delta_longitude
+    )
+    return (2.0 * EARTH_RADIUS_KM * np.arcsin(np.sqrt((1.0 - np.clip(central_angle_cosine, -1.0, 1.0)) / 2.0))).astype(
+        np.float32,
+        copy=False,
+    )
 
 
 def snap_city_to_cell_key(city: CityCandidate, *, grid_degrees: float = GRID_DEGREES) -> tuple[float, float]:

--- a/backend/cities.py
+++ b/backend/cities.py
@@ -519,9 +519,13 @@ def rank_indexed_city_scores(
             timings.distance_ms += (perf_counter() - distance_started) * 1000
 
         penalty_started = perf_counter()
-        penalty = winner_score * diversity_strength * np.exp(-distance_km / diversity_decay_km)
-        scores = np.where(active, np.maximum(0.0, scores * (1.0 - penalty)), scores)
         active[winner_index] = False
+        np.divide(distance_km, -diversity_decay_km, out=distance_km)
+        np.exp(distance_km, out=distance_km)
+        np.multiply(distance_km, winner_score * diversity_strength, out=distance_km)
+        np.subtract(1.0, distance_km, out=distance_km)
+        np.multiply(scores, distance_km, out=scores, where=active)
+        np.maximum(scores, 0.0, out=scores, where=active)
         if timings is not None:
             timings.penalty_ms += (perf_counter() - penalty_started) * 1000
 

--- a/backend/cities.py
+++ b/backend/cities.py
@@ -332,10 +332,9 @@ def _select_population_biased_winner(remaining: list[RankedCityCandidate]) -> Ra
 def _select_population_biased_winner_index(
     city_catalog: CityRankingCache,
     scores: NDArray[np.float32],
-    active: NDArray[np.bool],
+    active_indexes: NDArray[np.int32],
 ) -> int:
     """Prefer larger population centers when effective scores are nearly tied."""
-    active_indexes = np.flatnonzero(active)
     active_scores = scores[active_indexes]
     best_score = float(active_scores.max())
     near_tied_indexes = active_indexes[active_scores >= best_score - POPULATION_TIE_SCORE_WINDOW]
@@ -498,14 +497,14 @@ def rank_indexed_city_scores(
 
     setup_started = perf_counter()
     scores = cell_scores[city_catalog.climate_indexes].astype(np.float32, copy=True)
-    active = np.ones(scores.shape, dtype=bool)
+    active_indexes = np.arange(scores.shape[0], dtype=np.int32)
     ranked: list[CityScorePoint] = []
     if timings is not None:
         timings.setup_ms = (perf_counter() - setup_started) * 1000
 
-    while active.any() and len(ranked) < limit:
+    while active_indexes.size and len(ranked) < limit:
         winner_select_started = perf_counter()
-        winner_index = _select_population_biased_winner_index(city_catalog, scores, active)
+        winner_index = _select_population_biased_winner_index(city_catalog, scores, active_indexes)
         if timings is not None:
             timings.winner_select_ms += (perf_counter() - winner_select_started) * 1000
         winner_city = city_catalog.cities[winner_index]
@@ -513,19 +512,24 @@ def rank_indexed_city_scores(
         diversity_strength = _diversity_strength_for_rank(len(ranked))
         ranked.append(city_score_point(winner_city, winner_score, flag=city_catalog.flags[winner_index]))
 
+        active_indexes = active_indexes[active_indexes != winner_index]
+        if not active_indexes.size:
+            break
+
         distance_started = perf_counter()
-        distance_km = _haversine_distance_vector_km(city_catalog, winner_index)
+        distance_km = _haversine_distance_vector_km(city_catalog, winner_index, active_indexes)
         if timings is not None:
             timings.distance_ms += (perf_counter() - distance_started) * 1000
 
         penalty_started = perf_counter()
-        active[winner_index] = False
         np.divide(distance_km, -diversity_decay_km, out=distance_km)
         np.exp(distance_km, out=distance_km)
         np.multiply(distance_km, winner_score * diversity_strength, out=distance_km)
         np.subtract(1.0, distance_km, out=distance_km)
-        np.multiply(scores, distance_km, out=scores, where=active)
-        np.maximum(scores, 0.0, out=scores, where=active)
+        updated_scores = scores[active_indexes]
+        np.multiply(updated_scores, distance_km, out=updated_scores)
+        np.maximum(updated_scores, 0.0, out=updated_scores)
+        scores[active_indexes] = updated_scores
         if timings is not None:
             timings.penalty_ms += (perf_counter() - penalty_started) * 1000
 
@@ -569,17 +573,18 @@ def haversine_distance_km(lat1: float, lon1: float, lat2: float, lon2: float) ->
 def _haversine_distance_vector_km(
     city_catalog: CityRankingCache,
     winner_index: int,
+    candidate_indexes: NDArray[np.int32],
 ) -> NDArray[np.float32]:
     """Vectorized winner-to-all distances for one diversity-penalty update."""
     sine_latitude = city_catalog.sine_latitudes[winner_index]
     cosine_latitude = city_catalog.cosine_latitudes[winner_index]
     cosine_delta_longitude = (
-        city_catalog.cosine_longitudes[winner_index] * city_catalog.cosine_longitudes
-        + city_catalog.sine_longitudes[winner_index] * city_catalog.sine_longitudes
+        city_catalog.cosine_longitudes[winner_index] * city_catalog.cosine_longitudes[candidate_indexes]
+        + city_catalog.sine_longitudes[winner_index] * city_catalog.sine_longitudes[candidate_indexes]
     )
     central_angle_cosine = (
-        sine_latitude * city_catalog.sine_latitudes
-        + cosine_latitude * city_catalog.cosine_latitudes * cosine_delta_longitude
+        sine_latitude * city_catalog.sine_latitudes[candidate_indexes]
+        + cosine_latitude * city_catalog.cosine_latitudes[candidate_indexes] * cosine_delta_longitude
     )
     return (2.0 * EARTH_RADIUS_KM * np.arcsin(np.sqrt((1.0 - np.clip(central_angle_cosine, -1.0, 1.0)) / 2.0))).astype(
         np.float32,

--- a/backend/cities.py
+++ b/backend/cities.py
@@ -335,13 +335,16 @@ def _select_population_biased_winner_index(
     active: NDArray[np.bool],
 ) -> int:
     """Prefer larger population centers when effective scores are nearly tied."""
-    active_scores = np.where(active, scores, -1.0)
+    active_indexes = np.flatnonzero(active)
+    active_scores = scores[active_indexes]
     best_score = float(active_scores.max())
-    near_tied = np.flatnonzero(active & (scores >= best_score - POPULATION_TIE_SCORE_WINDOW))
-    return max(
-        near_tied.tolist(),
-        key=lambda index: (_candidate_population(city_catalog.cities[index]), float(scores[index])),
-    )
+    near_tied_indexes = active_indexes[active_scores >= best_score - POPULATION_TIE_SCORE_WINDOW]
+    near_tied_populations = city_catalog.populations[near_tied_indexes]
+    max_population = int(near_tied_populations.max(initial=0))
+    population_tied_indexes = near_tied_indexes[near_tied_populations == max_population]
+    if population_tied_indexes.size == 1:
+        return int(population_tied_indexes[0])
+    return int(population_tied_indexes[np.argmax(scores[population_tied_indexes])])
 
 
 @dataclass(frozen=True, slots=True)
@@ -350,6 +353,7 @@ class CityRankingCache:
 
     cities: tuple[CityCandidate, ...]
     climate_indexes: NDArray[np.int32]
+    populations: NDArray[np.int32]
     latitude_radians: NDArray[np.float32]
     longitude_radians: NDArray[np.float32]
     sine_latitudes: NDArray[np.float32]
@@ -368,6 +372,10 @@ class CityRankingCache:
 
         if self.latitude_radians.shape != (city_count,):
             msg = "latitude_radians must align with cities"
+            raise ValueError(msg)
+
+        if self.populations.shape != (city_count,):
+            msg = "populations must align with cities"
             raise ValueError(msg)
 
         if self.longitude_radians.shape != (city_count,):
@@ -412,6 +420,7 @@ class CityRankingCache:
         return cls(
             cities=cities,
             climate_indexes=climate_indexes,
+            populations=np.array([_candidate_population(city) for city in cities], dtype=np.int32),
             latitude_radians=latitude_radians,
             longitude_radians=longitude_radians,
             sine_latitudes=np.sin(latitude_radians).astype(np.float32, copy=False),

--- a/backend/cities.py
+++ b/backend/cities.py
@@ -332,9 +332,10 @@ def _select_population_biased_winner(remaining: list[RankedCityCandidate]) -> Ra
 def _select_population_biased_winner_index(
     city_catalog: CityRankingCache,
     scores: NDArray[np.float32],
-    active_indexes: NDArray[np.int32],
+    active: NDArray[np.bool],
 ) -> int:
     """Prefer larger population centers when effective scores are nearly tied."""
+    active_indexes = np.flatnonzero(active)
     active_scores = scores[active_indexes]
     best_score = float(active_scores.max())
     near_tied_indexes = active_indexes[active_scores >= best_score - POPULATION_TIE_SCORE_WINDOW]
@@ -497,14 +498,14 @@ def rank_indexed_city_scores(
 
     setup_started = perf_counter()
     scores = cell_scores[city_catalog.climate_indexes].astype(np.float32, copy=True)
-    active_indexes = np.arange(scores.shape[0], dtype=np.int32)
+    active = np.ones(scores.shape, dtype=bool)
     ranked: list[CityScorePoint] = []
     if timings is not None:
         timings.setup_ms = (perf_counter() - setup_started) * 1000
 
-    while active_indexes.size and len(ranked) < limit:
+    while active.any() and len(ranked) < limit:
         winner_select_started = perf_counter()
-        winner_index = _select_population_biased_winner_index(city_catalog, scores, active_indexes)
+        winner_index = _select_population_biased_winner_index(city_catalog, scores, active)
         if timings is not None:
             timings.winner_select_ms += (perf_counter() - winner_select_started) * 1000
         winner_city = city_catalog.cities[winner_index]
@@ -512,24 +513,19 @@ def rank_indexed_city_scores(
         diversity_strength = _diversity_strength_for_rank(len(ranked))
         ranked.append(city_score_point(winner_city, winner_score, flag=city_catalog.flags[winner_index]))
 
-        active_indexes = active_indexes[active_indexes != winner_index]
-        if not active_indexes.size:
-            break
-
         distance_started = perf_counter()
-        distance_km = _haversine_distance_vector_km(city_catalog, winner_index, active_indexes)
+        distance_km = _haversine_distance_vector_km(city_catalog, winner_index)
         if timings is not None:
             timings.distance_ms += (perf_counter() - distance_started) * 1000
 
         penalty_started = perf_counter()
+        active[winner_index] = False
         np.divide(distance_km, -diversity_decay_km, out=distance_km)
         np.exp(distance_km, out=distance_km)
         np.multiply(distance_km, winner_score * diversity_strength, out=distance_km)
         np.subtract(1.0, distance_km, out=distance_km)
-        updated_scores = scores[active_indexes]
-        np.multiply(updated_scores, distance_km, out=updated_scores)
-        np.maximum(updated_scores, 0.0, out=updated_scores)
-        scores[active_indexes] = updated_scores
+        np.multiply(scores, distance_km, out=scores, where=active)
+        np.maximum(scores, 0.0, out=scores, where=active)
         if timings is not None:
             timings.penalty_ms += (perf_counter() - penalty_started) * 1000
 
@@ -573,18 +569,17 @@ def haversine_distance_km(lat1: float, lon1: float, lat2: float, lon2: float) ->
 def _haversine_distance_vector_km(
     city_catalog: CityRankingCache,
     winner_index: int,
-    candidate_indexes: NDArray[np.int32],
 ) -> NDArray[np.float32]:
     """Vectorized winner-to-all distances for one diversity-penalty update."""
     sine_latitude = city_catalog.sine_latitudes[winner_index]
     cosine_latitude = city_catalog.cosine_latitudes[winner_index]
     cosine_delta_longitude = (
-        city_catalog.cosine_longitudes[winner_index] * city_catalog.cosine_longitudes[candidate_indexes]
-        + city_catalog.sine_longitudes[winner_index] * city_catalog.sine_longitudes[candidate_indexes]
+        city_catalog.cosine_longitudes[winner_index] * city_catalog.cosine_longitudes
+        + city_catalog.sine_longitudes[winner_index] * city_catalog.sine_longitudes
     )
     central_angle_cosine = (
-        sine_latitude * city_catalog.sine_latitudes[candidate_indexes]
-        + cosine_latitude * city_catalog.cosine_latitudes[candidate_indexes] * cosine_delta_longitude
+        sine_latitude * city_catalog.sine_latitudes
+        + cosine_latitude * city_catalog.cosine_latitudes * cosine_delta_longitude
     )
     return (2.0 * EARTH_RADIUS_KM * np.arcsin(np.sqrt((1.0 - np.clip(central_angle_cosine, -1.0, 1.0)) / 2.0))).astype(
         np.float32,

--- a/backend/cities.py
+++ b/backend/cities.py
@@ -492,7 +492,10 @@ def rank_indexed_city_scores(
     diversity_decay_km: float = CITY_DIVERSITY_DECAY_KM,
     timings: IndexedRankingTimings | None = None,
 ) -> list[CityScorePoint]:
-    """Rank cities from climate-matrix-aligned scores while keeping regional diversity suppression."""
+    """Rank cities from climate-matrix-aligned scores with regional diversity suppression.
+
+    If provided, ``timings`` is populated in place with indexed ranking substep timings.
+    """
     if not city_catalog.cities:
         return []
 

--- a/backend/cities.py
+++ b/backend/cities.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from time import perf_counter
 from typing import TYPE_CHECKING, TypedDict
 
 import numpy as np
@@ -291,6 +292,16 @@ class RegionalPenaltyCenter:
     strength: float = 1.0
 
 
+@dataclass(slots=True)
+class IndexedRankingTimings:
+    """Optional cold-path timings for indexed city ranking."""
+
+    setup_ms: float = 0.0
+    winner_select_ms: float = 0.0
+    distance_ms: float = 0.0
+    penalty_ms: float = 0.0
+
+
 def city_score_point(city: CityCandidate, score: float, *, flag: str | None = None) -> CityScorePoint:
     """Build the API score shape for one ranked city."""
     return {
@@ -452,26 +463,40 @@ def rank_indexed_city_scores(
     *,
     limit: int,
     diversity_decay_km: float = CITY_DIVERSITY_DECAY_KM,
+    timings: IndexedRankingTimings | None = None,
 ) -> list[CityScorePoint]:
     """Rank cities from climate-matrix-aligned scores while keeping regional diversity suppression."""
     if not city_catalog.cities:
         return []
 
+    setup_started = perf_counter()
     scores = cell_scores[city_catalog.climate_indexes].astype(np.float32, copy=True)
     active = np.ones(scores.shape, dtype=bool)
     ranked: list[CityScorePoint] = []
+    if timings is not None:
+        timings.setup_ms = (perf_counter() - setup_started) * 1000
 
     while active.any() and len(ranked) < limit:
+        winner_select_started = perf_counter()
         winner_index = _select_population_biased_winner_index(city_catalog, scores, active)
+        if timings is not None:
+            timings.winner_select_ms += (perf_counter() - winner_select_started) * 1000
         winner_city = city_catalog.cities[winner_index]
         winner_score = float(scores[winner_index])
         diversity_strength = _diversity_strength_for_rank(len(ranked))
         ranked.append(city_score_point(winner_city, winner_score, flag=city_catalog.flags[winner_index]))
 
+        distance_started = perf_counter()
         distance_km = _haversine_distance_vector_km(city_catalog, winner_index)
+        if timings is not None:
+            timings.distance_ms += (perf_counter() - distance_started) * 1000
+
+        penalty_started = perf_counter()
         penalty = winner_score * diversity_strength * np.exp(-distance_km / diversity_decay_km)
         scores = np.where(active, np.maximum(0.0, scores * (1.0 - penalty)), scores)
         active[winner_index] = False
+        if timings is not None:
+            timings.penalty_ms += (perf_counter() - penalty_started) * 1000
 
     return ranked
 

--- a/backend/heatmap.py
+++ b/backend/heatmap.py
@@ -32,7 +32,6 @@ DETAIL_PRESERVE_STRENGTH = 0.9
 PEAK_BOOST_THRESHOLD = 0.72
 PEAK_BOOST_STRENGTH = 1.0
 SCORE_CURVE_GAMMA = 1.35
-FINAL_SMOOTH_BLUR_RADIUS = 0.0
 _MERCATOR_MAX_RENDER_LATITUDE = MAP_PROJECTION.max_render_latitude
 
 if MAP_PROJECTION.name != "mercator" or _MERCATOR_MAX_RENDER_LATITUDE is None:
@@ -160,13 +159,6 @@ def _stylize_heatmap_gray(gray: NDArray[np.uint8]) -> NDArray[np.uint8]:
     return np.rint(curved * 255).astype(np.uint8)
 
 
-def _smooth_styled_heatmap_gray(gray: NDArray[np.uint8]) -> NDArray[np.uint8]:
-    """Calm coastal chatter in the styled output without smearing the whole field."""
-    if FINAL_SMOOTH_BLUR_RADIUS <= 0.0:
-        return gray
-    return np.asarray(Image.fromarray(gray, mode="L").filter(ImageFilter.GaussianBlur(radius=FINAL_SMOOTH_BLUR_RADIUS)))
-
-
 def render_heatmap_png_from_projection(projection: HeatmapProjection, scores: np.ndarray) -> bytes:
     """Rasterize one score vector aligned with the projection's source climate-matrix rows."""
     work_scores = scores[projection.score_indexes]
@@ -209,13 +201,12 @@ def render_heatmap_png_from_projection(projection: HeatmapProjection, scores: np
         dtype=np.uint8,
     )
     source_point_floor = np.zeros((HEIGHT, WIDTH), dtype=np.float32)
-    np.maximum.at(source_point_floor, (projection.ys, projection.xs), scores[projection.score_indexes])
+    np.maximum.at(source_point_floor, (projection.ys, projection.xs), work_scores)
     blended_gray = np.maximum(
         blended_gray,
         np.rint(source_point_floor * 255.0 * SOURCE_POINT_FLOOR_STRENGTH).astype(np.uint8),
     )
     styled_gray = _stylize_heatmap_gray((blended_gray * projection.land_mask).astype(np.uint8))
-    styled_gray = (_smooth_styled_heatmap_gray(styled_gray) * projection.land_mask).astype(np.uint8)
     rgba = _COLOR_RAMP_LOOKUP[styled_gray]
 
     buf = BytesIO()

--- a/backend/main.py
+++ b/backend/main.py
@@ -559,23 +559,27 @@ def create_app(  # noqa: C901, PLR0915
 
     app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
-    async def _serve_score_request(preferences: PreferenceInputs) -> _ScoreCacheResult:
+    async def _serve_score_request(preferences: PreferenceInputs, *, use_cache: bool = True) -> _ScoreCacheResult:
         queue_started = perf_counter()
         score_request_tracker.mark_waiting()
         async with score_request_semaphore:
             score_queue_depth, score_inflight = score_request_tracker.mark_started()
             queue_wait_ms = round((perf_counter() - queue_started) * 1000, 2)
             try:
-                raw_cache_result = await run_in_threadpool(
-                    _score_response_from_cache_or_repository,
-                    score_cache,
-                    heatmap_field_cache,
-                    repository,
-                    preferences,
-                )
+                if use_cache:
+                    raw_cache_result = await run_in_threadpool(
+                        _score_response_from_cache_or_repository,
+                        score_cache,
+                        heatmap_field_cache,
+                        repository,
+                        preferences,
+                    )
+                    cache_result = _coerce_score_cache_result(raw_cache_result)
+                else:
+                    response = await run_in_threadpool(build_score_response, repository, preferences)
+                    cache_result = _ScoreCacheResult(response=response, cache_hit=False, cache_status="bypass")
             finally:
                 score_request_tracker.mark_finished()
-        cache_result = _coerce_score_cache_result(raw_cache_result)
         logger.info(
             "score request served",
             extra={
@@ -591,9 +595,9 @@ def create_app(  # noqa: C901, PLR0915
         )
         return cache_result
 
-    async def _serve_heatmap_request(preferences: PreferenceInputs) -> bytes:
+    async def _serve_heatmap_request(preferences: PreferenceInputs, *, use_cache: bool = True) -> bytes:
         cache_key = _score_cache_key(preferences)
-        cached_heatmap_field = heatmap_field_cache.get(cache_key)
+        cached_heatmap_field = heatmap_field_cache.get(cache_key) if use_cache else None
         queue_started = perf_counter()
         async with heatmap_request_semaphore:
             queue_wait_ms = round((perf_counter() - queue_started) * 1000, 2)
@@ -680,42 +684,27 @@ def create_app(  # noqa: C901, PLR0915
         request: Request,
         suite: Annotated[str, Query(pattern="^(smoke|profile)$")] = "profile",
         include_heatmap: bool = True,
+        use_cache: bool = False,
     ) -> dict[str, object]:
         preferences_batch = _TEST_REQUEST_SUITES[suite]
         suite_started = perf_counter()
         results: list[dict[str, object]] = []
 
-        if preferences_batch:
-            first_preferences = preferences_batch[0]
-            duplicate_results = await asyncio.gather(
-                _serve_score_request(first_preferences),
-                _serve_score_request(first_preferences),
-            )
+        for preferences in preferences_batch:
+            cache_result = await _serve_score_request(preferences, use_cache=use_cache)
             if include_heatmap:
-                await _serve_heatmap_request(first_preferences)
-            results.append(
-                {
-                    "preferences": _score_log_fields(first_preferences),
-                    "score_cache_statuses": [result.cache_status for result in duplicate_results],
-                    "duplicate_run": True,
-                }
-            )
-
-        for preferences in preferences_batch[1:]:
-            cache_result = await _serve_score_request(preferences)
-            if include_heatmap:
-                await _serve_heatmap_request(preferences)
+                await _serve_heatmap_request(preferences, use_cache=use_cache)
             results.append(
                 {
                     "preferences": _score_log_fields(preferences),
                     "score_cache_statuses": [cache_result.cache_status],
-                    "duplicate_run": False,
                 }
             )
 
         return {
             "suite": suite,
             "include_heatmap": include_heatmap,
+            "use_cache": use_cache,
             "case_count": len(results),
             "elapsed_ms": round((perf_counter() - suite_started) * 1000, 2),
             "results": results,

--- a/backend/main.py
+++ b/backend/main.py
@@ -311,69 +311,6 @@ def _score_log_fields(preferences: PreferenceInputs) -> dict[str, int]:
     }
 
 
-_TEST_REQUEST_SUITES: dict[str, tuple[PreferenceInputs, ...]] = {
-    "smoke": (PreferenceInputs(**{preference.name: preference.value for preference in DEFAULT_PREFERENCES}),),
-    "profile": (
-        PreferenceInputs(
-            preferred_day_temperature=23,
-            summer_heat_limit=30,
-            winter_cold_limit=0,
-            dryness_preference=30,
-            sunshine_preference=50,
-        ),
-        PreferenceInputs(
-            preferred_day_temperature=15,
-            summer_heat_limit=30,
-            winter_cold_limit=0,
-            dryness_preference=30,
-            sunshine_preference=50,
-        ),
-        PreferenceInputs(
-            preferred_day_temperature=8,
-            summer_heat_limit=21,
-            winter_cold_limit=5,
-            dryness_preference=55,
-            sunshine_preference=80,
-        ),
-        PreferenceInputs(
-            preferred_day_temperature=26,
-            summer_heat_limit=40,
-            winter_cold_limit=-5,
-            dryness_preference=55,
-            sunshine_preference=80,
-        ),
-        PreferenceInputs(
-            preferred_day_temperature=4,
-            summer_heat_limit=37,
-            winter_cold_limit=-6,
-            dryness_preference=75,
-            sunshine_preference=50,
-        ),
-        PreferenceInputs(
-            preferred_day_temperature=34,
-            summer_heat_limit=37,
-            winter_cold_limit=-6,
-            dryness_preference=75,
-            sunshine_preference=50,
-        ),
-        PreferenceInputs(
-            preferred_day_temperature=1,
-            summer_heat_limit=31,
-            winter_cold_limit=1,
-            dryness_preference=75,
-            sunshine_preference=50,
-        ),
-        PreferenceInputs(
-            preferred_day_temperature=-5,
-            summer_heat_limit=31,
-            winter_cold_limit=-5,
-            dryness_preference=75,
-            sunshine_preference=50,
-        ),
-    ),
-}
-
-
 def _score_response_from_cache_or_repository(
     score_cache: _ScoreResponseCache,
     heatmap_field_cache: _HeatmapFieldCache,
@@ -559,27 +496,23 @@ def create_app(  # noqa: C901, PLR0915
 
     app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
-    async def _serve_score_request(preferences: PreferenceInputs, *, use_cache: bool = True) -> _ScoreCacheResult:
+    async def _serve_score_request(preferences: PreferenceInputs) -> _ScoreCacheResult:
         queue_started = perf_counter()
         score_request_tracker.mark_waiting()
         async with score_request_semaphore:
             score_queue_depth, score_inflight = score_request_tracker.mark_started()
             queue_wait_ms = round((perf_counter() - queue_started) * 1000, 2)
             try:
-                if use_cache:
-                    raw_cache_result = await run_in_threadpool(
-                        _score_response_from_cache_or_repository,
-                        score_cache,
-                        heatmap_field_cache,
-                        repository,
-                        preferences,
-                    )
-                    cache_result = _coerce_score_cache_result(raw_cache_result)
-                else:
-                    response = await run_in_threadpool(build_score_response, repository, preferences)
-                    cache_result = _ScoreCacheResult(response=response, cache_hit=False, cache_status="bypass")
+                raw_cache_result = await run_in_threadpool(
+                    _score_response_from_cache_or_repository,
+                    score_cache,
+                    heatmap_field_cache,
+                    repository,
+                    preferences,
+                )
             finally:
                 score_request_tracker.mark_finished()
+        cache_result = _coerce_score_cache_result(raw_cache_result)
         logger.info(
             "score request served",
             extra={
@@ -595,9 +528,9 @@ def create_app(  # noqa: C901, PLR0915
         )
         return cache_result
 
-    async def _serve_heatmap_request(preferences: PreferenceInputs, *, use_cache: bool = True) -> bytes:
+    async def _serve_heatmap_request(preferences: PreferenceInputs) -> bytes:
         cache_key = _score_cache_key(preferences)
-        cached_heatmap_field = heatmap_field_cache.get(cache_key) if use_cache else None
+        cached_heatmap_field = heatmap_field_cache.get(cache_key)
         queue_started = perf_counter()
         async with heatmap_request_semaphore:
             queue_wait_ms = round((perf_counter() - queue_started) * 1000, 2)
@@ -677,38 +610,6 @@ def create_app(  # noqa: C901, PLR0915
         if not heatmap_png:
             return Response(status_code=204)
         return Response(content=heatmap_png, media_type="image/png")
-
-    @app.get("/test")
-    @limiter.limit("5/minute")
-    async def test_run(
-        request: Request,
-        suite: Annotated[str, Query(pattern="^(smoke|profile)$")] = "profile",
-        include_heatmap: bool = True,
-        use_cache: bool = False,
-    ) -> dict[str, object]:
-        preferences_batch = _TEST_REQUEST_SUITES[suite]
-        suite_started = perf_counter()
-        results: list[dict[str, object]] = []
-
-        for preferences in preferences_batch:
-            cache_result = await _serve_score_request(preferences, use_cache=use_cache)
-            if include_heatmap:
-                await _serve_heatmap_request(preferences, use_cache=use_cache)
-            results.append(
-                {
-                    "preferences": _score_log_fields(preferences),
-                    "score_cache_statuses": [cache_result.cache_status],
-                }
-            )
-
-        return {
-            "suite": suite,
-            "include_heatmap": include_heatmap,
-            "use_cache": use_cache,
-            "case_count": len(results),
-            "elapsed_ms": round((perf_counter() - suite_started) * 1000, 2),
-            "results": results,
-        }
 
     @app.get("/probe")
     @limiter.limit("120/minute")

--- a/backend/main.py
+++ b/backend/main.py
@@ -57,6 +57,7 @@ SERVER_ERROR_STATUS_MIN = 500
 SCORE_CACHE_SIZE = 16
 HEATMAP_FIELD_CACHE_SIZE = 2
 HEATMAP_FIELD_CACHE_TTL_SECONDS = 20.0
+SCORE_REQUEST_CONCURRENCY = 2
 
 
 class _ScoreResponseCache:
@@ -470,8 +471,8 @@ def create_app(  # noqa: C901, PLR0915
     repository = climate_repository or build_default_climate_repository(resolve_climate_database_path())
     score_cache = _ScoreResponseCache(SCORE_CACHE_SIZE)
     heatmap_field_cache = _HeatmapFieldCache(HEATMAP_FIELD_CACHE_SIZE, HEATMAP_FIELD_CACHE_TTL_SECONDS)
-    # Serialize /score work per worker so repeated slider changes do not pile up CPU-bound builds.
-    score_request_semaphore = asyncio.Semaphore(1)
+    # Let a small number of /score builds overlap so slider bursts do not serialize behind one miss.
+    score_request_semaphore = asyncio.Semaphore(SCORE_REQUEST_CONCURRENCY)
     score_request_tracker = _RequestConcurrencyTracker()
     heatmap_request_semaphore = asyncio.Semaphore(1)
     preload_repository(repository)

--- a/backend/main.py
+++ b/backend/main.py
@@ -95,12 +95,16 @@ class _ScoreResponseCache:
         key: tuple[int, int, int, int, int],
         build: Callable[[], ScoreResponse],
     ) -> _ScoreCacheResult:
+        waited_on_inflight = False
         while True:
             with self._lock:
                 response = self._entries.get(key)
                 if response is not None:
                     self._entries.move_to_end(key)
-                    return _ScoreCacheResult(response=response, cache_hit=True)
+                    cache_status = "miss_waited" if waited_on_inflight else "hit"
+                    return _ScoreCacheResult(
+                        response=response, cache_hit=not waited_on_inflight, cache_status=cache_status
+                    )
 
                 inflight = self._inflight.get(key)
                 if inflight is None:
@@ -108,6 +112,7 @@ class _ScoreResponseCache:
                     self._inflight[key] = inflight
                     break
 
+            waited_on_inflight = True
             inflight.wait()
 
         try:
@@ -123,12 +128,13 @@ class _ScoreResponseCache:
             if len(self._entries) > self.max_entries:
                 self._entries.popitem(last=False)
             self._inflight.pop(key).set()
-            return _ScoreCacheResult(response=response, cache_hit=False)
+            return _ScoreCacheResult(response=response, cache_hit=False, cache_status="miss_built")
 
 
 class _ScoreCacheResult(NamedTuple):
     response: ScoreResponse
     cache_hit: bool
+    cache_status: str
 
 
 class _HeatmapFieldCache:
@@ -163,6 +169,30 @@ class _HeatmapFieldCache:
         expired_keys = [key for key, (stored_at, _field) in self._entries.items() if now - stored_at > self.ttl_seconds]
         for key in expired_keys:
             self._entries.pop(key, None)
+
+
+class _RequestConcurrencyTracker:
+    """Track waiting and active request counts for one route class."""
+
+    def __init__(self) -> None:
+        self._waiting = 0
+        self._active = 0
+        self._lock = threading.Lock()
+
+    def mark_waiting(self) -> int:
+        with self._lock:
+            self._waiting += 1
+            return self._waiting
+
+    def mark_started(self) -> tuple[int, int]:
+        with self._lock:
+            self._waiting -= 1
+            self._active += 1
+            return self._waiting, self._active
+
+    def mark_finished(self) -> None:
+        with self._lock:
+            self._active -= 1
 
 
 class _SupportsProbeRepository(Protocol):
@@ -300,7 +330,7 @@ def _score_response_from_cache_or_repository(
 def _coerce_score_cache_result(result: _ScoreCacheResult | ScoreResponse) -> _ScoreCacheResult:
     if isinstance(result, _ScoreCacheResult):
         return result
-    return _ScoreCacheResult(response=result, cache_hit=False)
+    return _ScoreCacheResult(response=result, cache_hit=False, cache_status="miss_built")
 
 
 def _heatmap_url(preferences: PreferenceInputs) -> str:
@@ -442,6 +472,7 @@ def create_app(  # noqa: C901, PLR0915
     heatmap_field_cache = _HeatmapFieldCache(HEATMAP_FIELD_CACHE_SIZE, HEATMAP_FIELD_CACHE_TTL_SECONDS)
     # Serialize /score work per worker so repeated slider changes do not pile up CPU-bound builds.
     score_request_semaphore = asyncio.Semaphore(1)
+    score_request_tracker = _RequestConcurrencyTracker()
     heatmap_request_semaphore = asyncio.Semaphore(1)
     preload_repository(repository)
 
@@ -481,15 +512,20 @@ def create_app(  # noqa: C901, PLR0915
     async def score(request: Request, preferences: Annotated[PreferenceInputs, Form()]) -> dict[str, object]:
         try:
             queue_started = perf_counter()
+            score_request_tracker.mark_waiting()
             async with score_request_semaphore:
+                score_queue_depth, score_inflight = score_request_tracker.mark_started()
                 queue_wait_ms = round((perf_counter() - queue_started) * 1000, 2)
-                raw_cache_result = await run_in_threadpool(
-                    _score_response_from_cache_or_repository,
-                    score_cache,
-                    heatmap_field_cache,
-                    repository,
-                    preferences,
-                )
+                try:
+                    raw_cache_result = await run_in_threadpool(
+                        _score_response_from_cache_or_repository,
+                        score_cache,
+                        heatmap_field_cache,
+                        repository,
+                        preferences,
+                    )
+                finally:
+                    score_request_tracker.mark_finished()
             cache_result = _coerce_score_cache_result(raw_cache_result)
             logger.info(
                 "score request served",
@@ -497,7 +533,10 @@ def create_app(  # noqa: C901, PLR0915
                     "event": "score_request_route",
                     "outcome": "ok",
                     "cache_hit": cache_result.cache_hit,
+                    "cache_status": cache_result.cache_status,
                     "queue_wait_ms": queue_wait_ms,
+                    "score_queue_depth": score_queue_depth,
+                    "score_inflight": score_inflight,
                     **_score_log_fields(preferences),
                 },
             )

--- a/backend/main.py
+++ b/backend/main.py
@@ -311,6 +311,69 @@ def _score_log_fields(preferences: PreferenceInputs) -> dict[str, int]:
     }
 
 
+_TEST_REQUEST_SUITES: dict[str, tuple[PreferenceInputs, ...]] = {
+    "smoke": (PreferenceInputs(**{preference.name: preference.value for preference in DEFAULT_PREFERENCES}),),
+    "profile": (
+        PreferenceInputs(
+            preferred_day_temperature=23,
+            summer_heat_limit=30,
+            winter_cold_limit=0,
+            dryness_preference=30,
+            sunshine_preference=50,
+        ),
+        PreferenceInputs(
+            preferred_day_temperature=15,
+            summer_heat_limit=30,
+            winter_cold_limit=0,
+            dryness_preference=30,
+            sunshine_preference=50,
+        ),
+        PreferenceInputs(
+            preferred_day_temperature=8,
+            summer_heat_limit=21,
+            winter_cold_limit=5,
+            dryness_preference=55,
+            sunshine_preference=80,
+        ),
+        PreferenceInputs(
+            preferred_day_temperature=26,
+            summer_heat_limit=40,
+            winter_cold_limit=-5,
+            dryness_preference=55,
+            sunshine_preference=80,
+        ),
+        PreferenceInputs(
+            preferred_day_temperature=4,
+            summer_heat_limit=37,
+            winter_cold_limit=-6,
+            dryness_preference=75,
+            sunshine_preference=50,
+        ),
+        PreferenceInputs(
+            preferred_day_temperature=34,
+            summer_heat_limit=37,
+            winter_cold_limit=-6,
+            dryness_preference=75,
+            sunshine_preference=50,
+        ),
+        PreferenceInputs(
+            preferred_day_temperature=1,
+            summer_heat_limit=31,
+            winter_cold_limit=1,
+            dryness_preference=75,
+            sunshine_preference=50,
+        ),
+        PreferenceInputs(
+            preferred_day_temperature=-5,
+            summer_heat_limit=31,
+            winter_cold_limit=-5,
+            dryness_preference=75,
+            sunshine_preference=50,
+        ),
+    ),
+}
+
+
 def _score_response_from_cache_or_repository(
     score_cache: _ScoreResponseCache,
     heatmap_field_cache: _HeatmapFieldCache,
@@ -496,6 +559,63 @@ def create_app(  # noqa: C901, PLR0915
 
     app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
+    async def _serve_score_request(preferences: PreferenceInputs) -> _ScoreCacheResult:
+        queue_started = perf_counter()
+        score_request_tracker.mark_waiting()
+        async with score_request_semaphore:
+            score_queue_depth, score_inflight = score_request_tracker.mark_started()
+            queue_wait_ms = round((perf_counter() - queue_started) * 1000, 2)
+            try:
+                raw_cache_result = await run_in_threadpool(
+                    _score_response_from_cache_or_repository,
+                    score_cache,
+                    heatmap_field_cache,
+                    repository,
+                    preferences,
+                )
+            finally:
+                score_request_tracker.mark_finished()
+        cache_result = _coerce_score_cache_result(raw_cache_result)
+        logger.info(
+            "score request served",
+            extra={
+                "event": "score_request_route",
+                "outcome": "ok",
+                "cache_hit": cache_result.cache_hit,
+                "cache_status": cache_result.cache_status,
+                "queue_wait_ms": queue_wait_ms,
+                "score_queue_depth": score_queue_depth,
+                "score_inflight": score_inflight,
+                **_score_log_fields(preferences),
+            },
+        )
+        return cache_result
+
+    async def _serve_heatmap_request(preferences: PreferenceInputs) -> bytes:
+        cache_key = _score_cache_key(preferences)
+        cached_heatmap_field = heatmap_field_cache.get(cache_key)
+        queue_started = perf_counter()
+        async with heatmap_request_semaphore:
+            queue_wait_ms = round((perf_counter() - queue_started) * 1000, 2)
+            heatmap_png = await run_in_threadpool(
+                build_heatmap_response,
+                repository,
+                preferences,
+                cached_heatmap_field=cached_heatmap_field,
+            )
+        outcome = "ok" if heatmap_png else "empty"
+        logger.info(
+            "heatmap request served",
+            extra={
+                "event": "heatmap_request_route",
+                "outcome": outcome,
+                "score_field_cache_hit": cached_heatmap_field is not None,
+                "queue_wait_ms": queue_wait_ms,
+                **_score_log_fields(preferences),
+            },
+        )
+        return heatmap_png
+
     @app.get("/health")
     async def health() -> dict[str, str]:
         return {"status": "ok"}
@@ -512,35 +632,7 @@ def create_app(  # noqa: C901, PLR0915
     @limiter.limit("30/minute")
     async def score(request: Request, preferences: Annotated[PreferenceInputs, Form()]) -> dict[str, object]:
         try:
-            queue_started = perf_counter()
-            score_request_tracker.mark_waiting()
-            async with score_request_semaphore:
-                score_queue_depth, score_inflight = score_request_tracker.mark_started()
-                queue_wait_ms = round((perf_counter() - queue_started) * 1000, 2)
-                try:
-                    raw_cache_result = await run_in_threadpool(
-                        _score_response_from_cache_or_repository,
-                        score_cache,
-                        heatmap_field_cache,
-                        repository,
-                        preferences,
-                    )
-                finally:
-                    score_request_tracker.mark_finished()
-            cache_result = _coerce_score_cache_result(raw_cache_result)
-            logger.info(
-                "score request served",
-                extra={
-                    "event": "score_request_route",
-                    "outcome": "ok",
-                    "cache_hit": cache_result.cache_hit,
-                    "cache_status": cache_result.cache_status,
-                    "queue_wait_ms": queue_wait_ms,
-                    "score_queue_depth": score_queue_depth,
-                    "score_inflight": score_inflight,
-                    **_score_log_fields(preferences),
-                },
-            )
+            cache_result = await _serve_score_request(preferences)
         except ClimateDataError as error:
             logger.exception(
                 "score request failed",
@@ -563,28 +655,7 @@ def create_app(  # noqa: C901, PLR0915
         preferences: Annotated[PreferenceInputs, Depends(probe_preferences_dependency)],
     ) -> Response:
         try:
-            cache_key = _score_cache_key(preferences)
-            cached_heatmap_field = heatmap_field_cache.get(cache_key)
-            queue_started = perf_counter()
-            async with heatmap_request_semaphore:
-                queue_wait_ms = round((perf_counter() - queue_started) * 1000, 2)
-                heatmap_png = await run_in_threadpool(
-                    build_heatmap_response,
-                    repository,
-                    preferences,
-                    cached_heatmap_field=cached_heatmap_field,
-                )
-            outcome = "ok" if heatmap_png else "empty"
-            logger.info(
-                "heatmap request served",
-                extra={
-                    "event": "heatmap_request_route",
-                    "outcome": outcome,
-                    "score_field_cache_hit": cached_heatmap_field is not None,
-                    "queue_wait_ms": queue_wait_ms,
-                    **_score_log_fields(preferences),
-                },
-            )
+            heatmap_png = await _serve_heatmap_request(preferences)
         except ClimateDataError as error:
             logger.exception(
                 "heatmap request failed",
@@ -602,6 +673,53 @@ def create_app(  # noqa: C901, PLR0915
         if not heatmap_png:
             return Response(status_code=204)
         return Response(content=heatmap_png, media_type="image/png")
+
+    @app.get("/test")
+    @limiter.limit("5/minute")
+    async def test_run(
+        request: Request,
+        suite: Annotated[str, Query(pattern="^(smoke|profile)$")] = "profile",
+        include_heatmap: bool = True,
+    ) -> dict[str, object]:
+        preferences_batch = _TEST_REQUEST_SUITES[suite]
+        suite_started = perf_counter()
+        results: list[dict[str, object]] = []
+
+        if preferences_batch:
+            first_preferences = preferences_batch[0]
+            duplicate_results = await asyncio.gather(
+                _serve_score_request(first_preferences),
+                _serve_score_request(first_preferences),
+            )
+            if include_heatmap:
+                await _serve_heatmap_request(first_preferences)
+            results.append(
+                {
+                    "preferences": _score_log_fields(first_preferences),
+                    "score_cache_statuses": [result.cache_status for result in duplicate_results],
+                    "duplicate_run": True,
+                }
+            )
+
+        for preferences in preferences_batch[1:]:
+            cache_result = await _serve_score_request(preferences)
+            if include_heatmap:
+                await _serve_heatmap_request(preferences)
+            results.append(
+                {
+                    "preferences": _score_log_fields(preferences),
+                    "score_cache_statuses": [cache_result.cache_status],
+                    "duplicate_run": False,
+                }
+            )
+
+        return {
+            "suite": suite,
+            "include_heatmap": include_heatmap,
+            "case_count": len(results),
+            "elapsed_ms": round((perf_counter() - suite_started) * 1000, 2),
+            "results": results,
+        }
 
     @app.get("/probe")
     @limiter.limit("120/minute")

--- a/backend/score_service.py
+++ b/backend/score_service.py
@@ -36,8 +36,8 @@ if TYPE_CHECKING:
 INITIAL_CITY_RESULTS = 30
 SIDEBAR_CONTINENT_RESERVE = 30
 CONTINENT_COUNT = 6
-# One and a half diversified passes per continent still leaves enough slack for backfill while cutting cold ranking cost.
-RANKING_POOL_SIZE = SIDEBAR_CONTINENT_RESERVE * CONTINENT_COUNT * 3 // 2
+# One diversified pass per continent keeps the candidate pool bounded to the eventual sidebar footprint.
+RANKING_POOL_SIZE = SIDEBAR_CONTINENT_RESERVE * CONTINENT_COUNT
 logger = logging.getLogger(__name__)
 
 

--- a/backend/score_service.py
+++ b/backend/score_service.py
@@ -42,6 +42,10 @@ class ScoreTimings:
     scoring_ms: float = 0.0
     normalize_ms: float = 0.0
     ranking_ms: float = 0.0
+    ranking_filter_ms: float = 0.0
+    ranking_candidates_ms: float = 0.0
+    ranking_sidebar_ms: float = 0.0
+    ranking_rescore_ms: float = 0.0
     heatmap_ms: float = 0.0
     response_ms: float = 0.0
     total_ms: float = 0.0
@@ -336,6 +340,10 @@ def _log_score_timings(  # noqa: PLR0913
             "scoring_ms": timings.scoring_ms,
             "normalize_ms": timings.normalize_ms,
             "ranking_ms": timings.ranking_ms,
+            "ranking_filter_ms": timings.ranking_filter_ms,
+            "ranking_candidates_ms": timings.ranking_candidates_ms,
+            "ranking_sidebar_ms": timings.ranking_sidebar_ms,
+            "ranking_rescore_ms": timings.ranking_rescore_ms,
             "heatmap_ms": timings.heatmap_ms,
             "response_ms": timings.response_ms,
             "climate_cells": climate_cell_count,
@@ -436,12 +444,20 @@ def _build_score_response_from_matrix(
         )
 
     ranking_started = perf_counter()
+    ranking_filter_started = perf_counter()
     ranking_catalog = _filter_ranking_catalog(indexed_cities)
+    timings.ranking_filter_ms = _elapsed_ms(ranking_filter_started)
     # Build a large diversity-suppressed pool so the continent fill draws from
     # already-spread candidates rather than raw score clusters.
+    ranking_candidates_started = perf_counter()
     diverse_pool = rank_indexed_city_scores(ranking_catalog, normalized_scores, limit=RANKING_POOL_SIZE)
+    timings.ranking_candidates_ms = _elapsed_ms(ranking_candidates_started)
+    ranking_sidebar_started = perf_counter()
     top_cities = _build_ranked_sidebar_scores(diverse_pool)
+    timings.ranking_sidebar_ms = _elapsed_ms(ranking_sidebar_started)
+    ranking_rescore_started = perf_counter()
     top_cities = _rescore_city_points_from_cache(ranking_catalog, top_cities, raw_scores)
+    timings.ranking_rescore_ms = _elapsed_ms(ranking_rescore_started)
     timings.ranking_ms = _elapsed_ms(ranking_started)
 
     return _finalize_score_response(
@@ -507,10 +523,18 @@ def _build_score_response_from_cells(
         store_heatmap_field(HeatmapField(normalized_scores=normalized_scores))
 
     ranking_started = perf_counter()
+    ranking_filter_started = perf_counter()
     ranking_catalog = _filter_city_candidates(cities)
+    timings.ranking_filter_ms = _elapsed_ms(ranking_filter_started)
+    ranking_candidates_started = perf_counter()
     diverse_pool = rank_city_scores(ranking_catalog, normalized_scores, limit=RANKING_POOL_SIZE)
+    timings.ranking_candidates_ms = _elapsed_ms(ranking_candidates_started)
+    ranking_sidebar_started = perf_counter()
     top_cities = _build_ranked_sidebar_scores(diverse_pool)
+    timings.ranking_sidebar_ms = _elapsed_ms(ranking_sidebar_started)
+    ranking_rescore_started = perf_counter()
     top_cities = _rescore_city_points_from_cells(ranking_catalog, top_cities, raw_scores)
+    timings.ranking_rescore_ms = _elapsed_ms(ranking_rescore_started)
     timings.ranking_ms = _elapsed_ms(ranking_started)
 
     return _finalize_score_response(

--- a/backend/score_service.py
+++ b/backend/score_service.py
@@ -36,8 +36,8 @@ if TYPE_CHECKING:
 INITIAL_CITY_RESULTS = 30
 SIDEBAR_CONTINENT_RESERVE = 30
 CONTINENT_COUNT = 6
-# Keep a larger diversified pool so continent backfill doesn't fall back to clustered raw-score picks.
-RANKING_POOL_SIZE = SIDEBAR_CONTINENT_RESERVE * CONTINENT_COUNT * 3
+# Two diversified passes per continent still leave enough slack for backfill without overpaying the ranking loop.
+RANKING_POOL_SIZE = SIDEBAR_CONTINENT_RESERVE * CONTINENT_COUNT * 2
 logger = logging.getLogger(__name__)
 
 

--- a/backend/score_service.py
+++ b/backend/score_service.py
@@ -7,11 +7,19 @@ from typing import TYPE_CHECKING, TypedDict, cast
 
 import numpy as np
 
-from backend.cities import CityCandidate, CityRankingCache, CityScorePoint, rank_city_scores, rank_indexed_city_scores
+from backend.cities import (
+    CityCandidate,
+    CityRankingCache,
+    CityScorePoint,
+    IndexedRankingTimings,
+    rank_city_scores,
+    rank_indexed_city_scores,
+)
 from backend.config import RANKING_MIN_POPULATION
 from backend.heatmap import render_heatmap_png, render_heatmap_png_from_arrays, render_heatmap_png_from_projection
 from backend.scoring import (
     CellScorePoint,
+    MatrixScoreTimings,
     PreferenceInputs,
     normalize_score_array,
     score_climate_cells,
@@ -44,8 +52,17 @@ class ScoreTimings:
     ranking_ms: float = 0.0
     ranking_filter_ms: float = 0.0
     ranking_candidates_ms: float = 0.0
+    ranking_candidates_setup_ms: float = 0.0
+    ranking_candidates_winner_select_ms: float = 0.0
+    ranking_candidates_distance_ms: float = 0.0
+    ranking_candidates_penalty_ms: float = 0.0
     ranking_sidebar_ms: float = 0.0
     ranking_rescore_ms: float = 0.0
+    scoring_setup_ms: float = 0.0
+    scoring_temperature_ms: float = 0.0
+    scoring_rain_ms: float = 0.0
+    scoring_sun_ms: float = 0.0
+    scoring_combine_ms: float = 0.0
     heatmap_ms: float = 0.0
     response_ms: float = 0.0
     total_ms: float = 0.0
@@ -338,10 +355,19 @@ def _log_score_timings(  # noqa: PLR0913
             "cells_ms": timings.cells_ms,
             "cities_ms": timings.cities_ms,
             "scoring_ms": timings.scoring_ms,
+            "scoring_setup_ms": timings.scoring_setup_ms,
+            "scoring_temperature_ms": timings.scoring_temperature_ms,
+            "scoring_rain_ms": timings.scoring_rain_ms,
+            "scoring_sun_ms": timings.scoring_sun_ms,
+            "scoring_combine_ms": timings.scoring_combine_ms,
             "normalize_ms": timings.normalize_ms,
             "ranking_ms": timings.ranking_ms,
             "ranking_filter_ms": timings.ranking_filter_ms,
             "ranking_candidates_ms": timings.ranking_candidates_ms,
+            "ranking_candidates_setup_ms": timings.ranking_candidates_setup_ms,
+            "ranking_candidates_winner_select_ms": timings.ranking_candidates_winner_select_ms,
+            "ranking_candidates_distance_ms": timings.ranking_candidates_distance_ms,
+            "ranking_candidates_penalty_ms": timings.ranking_candidates_penalty_ms,
             "ranking_sidebar_ms": timings.ranking_sidebar_ms,
             "ranking_rescore_ms": timings.ranking_rescore_ms,
             "heatmap_ms": timings.heatmap_ms,
@@ -409,8 +435,14 @@ def _build_score_response_from_matrix(
     context = ScoreContext(climate_cell_count=len(climate_matrix.latitudes), city_count=len(indexed_cities.cities))
 
     scoring_started = perf_counter()
-    raw_scores = score_climate_matrix(climate_matrix, preferences)
+    scoring_breakdown = MatrixScoreTimings()
+    raw_scores = score_climate_matrix(climate_matrix, preferences, timings=scoring_breakdown)
     timings.scoring_ms = _elapsed_ms(scoring_started)
+    timings.scoring_setup_ms = scoring_breakdown.setup_ms
+    timings.scoring_temperature_ms = scoring_breakdown.temperature_ms
+    timings.scoring_rain_ms = scoring_breakdown.rain_ms
+    timings.scoring_sun_ms = scoring_breakdown.sun_ms
+    timings.scoring_combine_ms = scoring_breakdown.combine_ms
 
     if raw_scores.size == 0:
         return _empty_score_response(
@@ -450,8 +482,18 @@ def _build_score_response_from_matrix(
     # Build a large diversity-suppressed pool so the continent fill draws from
     # already-spread candidates rather than raw score clusters.
     ranking_candidates_started = perf_counter()
-    diverse_pool = rank_indexed_city_scores(ranking_catalog, normalized_scores, limit=RANKING_POOL_SIZE)
+    ranking_candidates_breakdown = IndexedRankingTimings()
+    diverse_pool = rank_indexed_city_scores(
+        ranking_catalog,
+        normalized_scores,
+        limit=RANKING_POOL_SIZE,
+        timings=ranking_candidates_breakdown,
+    )
     timings.ranking_candidates_ms = _elapsed_ms(ranking_candidates_started)
+    timings.ranking_candidates_setup_ms = ranking_candidates_breakdown.setup_ms
+    timings.ranking_candidates_winner_select_ms = ranking_candidates_breakdown.winner_select_ms
+    timings.ranking_candidates_distance_ms = ranking_candidates_breakdown.distance_ms
+    timings.ranking_candidates_penalty_ms = ranking_candidates_breakdown.penalty_ms
     ranking_sidebar_started = perf_counter()
     top_cities = _build_ranked_sidebar_scores(diverse_pool)
     timings.ranking_sidebar_ms = _elapsed_ms(ranking_sidebar_started)

--- a/backend/score_service.py
+++ b/backend/score_service.py
@@ -36,8 +36,8 @@ if TYPE_CHECKING:
 INITIAL_CITY_RESULTS = 30
 SIDEBAR_CONTINENT_RESERVE = 30
 CONTINENT_COUNT = 6
-# Two diversified passes per continent still leave enough slack for backfill without overpaying the ranking loop.
-RANKING_POOL_SIZE = SIDEBAR_CONTINENT_RESERVE * CONTINENT_COUNT * 2
+# One and a half diversified passes per continent still leaves enough slack for backfill while cutting cold ranking cost.
+RANKING_POOL_SIZE = SIDEBAR_CONTINENT_RESERVE * CONTINENT_COUNT * 3 // 2
 logger = logging.getLogger(__name__)
 
 

--- a/backend/score_service.py
+++ b/backend/score_service.py
@@ -479,8 +479,8 @@ def _build_score_response_from_matrix(
     ranking_filter_started = perf_counter()
     ranking_catalog = _filter_ranking_catalog(indexed_cities)
     timings.ranking_filter_ms = _elapsed_ms(ranking_filter_started)
-    # Build a large diversity-suppressed pool so the continent fill draws from
-    # already-spread candidates rather than raw score clusters.
+    # Build a diversity-suppressed pool so continent fill draws from already-spread
+    # candidates rather than clustered raw-score picks.
     ranking_candidates_started = perf_counter()
     ranking_candidates_breakdown = IndexedRankingTimings()
     diverse_pool = rank_indexed_city_scores(

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from time import perf_counter
 from typing import TYPE_CHECKING, TypedDict, cast
 
 import numpy as np
@@ -278,6 +279,17 @@ class CellScorePoint(TypedDict):
     score: float
 
 
+@dataclass(slots=True)
+class MatrixScoreTimings:
+    """Optional cold-path timings for vectorized matrix scoring."""
+
+    setup_ms: float = 0.0
+    temperature_ms: float = 0.0
+    rain_ms: float = 0.0
+    sun_ms: float = 0.0
+    combine_ms: float = 0.0
+
+
 STUB_CLIMATE_CELLS: tuple[ClimateCell, ...] = (
     ClimateCell(
         lat=37.5,
@@ -480,8 +492,14 @@ def score_climate_cells(climate_cells: tuple[ClimateCell, ...], preferences: Pre
     ]
 
 
-def score_climate_matrix(climate_matrix: ClimateMatrix, preferences: PreferenceInputs) -> NDArray[np.float32]:
+def score_climate_matrix(
+    climate_matrix: ClimateMatrix,
+    preferences: PreferenceInputs,
+    *,
+    timings: MatrixScoreTimings | None = None,
+) -> NDArray[np.float32]:
     """Score the compact climate matrix with vectorized NumPy operations."""
+    setup_started = perf_counter()
     tolerated_cloud_cover = MAX_TOLERATED_CLOUD_COVER - (
         (MAX_TOLERATED_CLOUD_COVER - MIN_TOLERATED_CLOUD_COVER) * (preferences.sunshine_preference / 100.0)
     )
@@ -494,6 +512,10 @@ def score_climate_matrix(climate_matrix: ClimateMatrix, preferences: PreferenceI
         preferences.dryness_preference,
         preferences.sunshine_preference,
     )
+    if timings is not None:
+        timings.setup_ms = (perf_counter() - setup_started) * 1000
+
+    temperature_started = perf_counter()
     ideal_distance = np.maximum(
         np.abs(climate_matrix.typical_highs_c - preferred_day_temperature) - TEMPERATURE_COMFORT_BAND_C, 0.0
     )
@@ -507,7 +529,10 @@ def score_climate_matrix(climate_matrix: ClimateMatrix, preferences: PreferenceI
         * heat_scores**TEMPERATURE_HEAT_WEIGHT
         * cold_scores**TEMPERATURE_COLD_WEIGHT
     ).astype(np.float32, copy=False)
+    if timings is not None:
+        timings.temperature_ms = (perf_counter() - temperature_started) * 1000
 
+    rain_started = perf_counter()
     typical_rain_scores = np.clip(
         1.0 - (climate_matrix.median_precipitation_mm / SATURATING_MONTHLY_RAIN_MM) * dryness_ratio,
         0.0,
@@ -522,7 +547,10 @@ def score_climate_matrix(climate_matrix: ClimateMatrix, preferences: PreferenceI
         np.maximum(typical_rain_scores, MULTIPLICATIVE_SCORE_FLOOR) ** PRECIPITATION_PROFILE_MEDIAN_WEIGHT
         * np.maximum(wettest_month_scores, MULTIPLICATIVE_SCORE_FLOOR) ** PRECIPITATION_PROFILE_PEAK_WEIGHT
     ).astype(np.float32, copy=False)
+    if timings is not None:
+        timings.rain_ms = (perf_counter() - rain_started) * 1000
 
+    sun_started = perf_counter()
     average_excess_ratio = (climate_matrix.average_cloud_cover_pct - tolerated_cloud_cover) / cloud_denominator
     average_sun_scores = np.where(
         climate_matrix.average_cloud_cover_pct <= tolerated_cloud_cover,
@@ -542,13 +570,19 @@ def score_climate_matrix(climate_matrix: ClimateMatrix, preferences: PreferenceI
         np.float32,
         copy=False,
     )
+    if timings is not None:
+        timings.sun_ms = (perf_counter() - sun_started) * 1000
 
+    combine_started = perf_counter()
     preference_scores = (rain_scores**rain_weight * sun_scores**sun_weight).astype(np.float32, copy=False)
-    return np.clip(
+    scores = np.clip(
         temperature_scores**temperature_weight * preference_scores ** (1 - temperature_weight),
         0.0,
         1.0,
     ).astype(np.float32, copy=False)
+    if timings is not None:
+        timings.combine_ms = (perf_counter() - combine_started) * 1000
+    return scores
 
 
 def normalize_score_array(scores: NDArray[np.float32]) -> NDArray[np.float32]:

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -551,21 +551,28 @@ def score_climate_matrix(
         timings.rain_ms = (perf_counter() - rain_started) * 1000
 
     sun_started = perf_counter()
-    average_excess_ratio = (climate_matrix.average_cloud_cover_pct - tolerated_cloud_cover) / cloud_denominator
-    average_sun_scores = np.where(
-        climate_matrix.average_cloud_cover_pct <= tolerated_cloud_cover,
-        1.0,
-        np.clip(1.0 - average_excess_ratio**2, 0.0, 1.0),
+    average_excess_ratio = np.subtract(
+        climate_matrix.average_cloud_cover_pct.astype(np.float32, copy=False),
+        tolerated_cloud_cover,
+        dtype=np.float32,
     )
-    gloom_excess_ratio = (climate_matrix.gloomiest_cloud_cover_pct - tolerated_cloud_cover) / cloud_denominator
-    gloomiest_sun_scores = np.where(
-        climate_matrix.gloomiest_cloud_cover_pct <= tolerated_cloud_cover,
-        1.0,
-        np.clip(1.0 - gloom_excess_ratio**2, 0.0, 1.0),
+    np.divide(average_excess_ratio, cloud_denominator, out=average_excess_ratio)
+    np.clip(average_excess_ratio, 0.0, None, out=average_excess_ratio)
+    average_sun_scores = np.subtract(1.0, average_excess_ratio * average_excess_ratio, dtype=np.float32)
+    np.clip(average_sun_scores, MULTIPLICATIVE_SCORE_FLOOR, 1.0, out=average_sun_scores)
+
+    gloom_excess_ratio = np.subtract(
+        climate_matrix.gloomiest_cloud_cover_pct.astype(np.float32, copy=False),
+        tolerated_cloud_cover,
+        dtype=np.float32,
     )
+    np.divide(gloom_excess_ratio, cloud_denominator, out=gloom_excess_ratio)
+    np.clip(gloom_excess_ratio, 0.0, None, out=gloom_excess_ratio)
+    gloomiest_sun_scores = np.subtract(1.0, gloom_excess_ratio * gloom_excess_ratio, dtype=np.float32)
+    np.clip(gloomiest_sun_scores, MULTIPLICATIVE_SCORE_FLOOR, 1.0, out=gloomiest_sun_scores)
+
     sun_scores = (
-        np.maximum(average_sun_scores, MULTIPLICATIVE_SCORE_FLOOR) ** SUN_PROFILE_AVERAGE_WEIGHT
-        * np.maximum(gloomiest_sun_scores, MULTIPLICATIVE_SCORE_FLOOR) ** SUN_PROFILE_GLOOM_WEIGHT
+        average_sun_scores**SUN_PROFILE_AVERAGE_WEIGHT * gloomiest_sun_scores**SUN_PROFILE_GLOOM_WEIGHT
     ).astype(
         np.float32,
         copy=False,

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -311,6 +311,44 @@ def _combine_score_blocks(
     return scores
 
 
+def _temperature_score_block(
+    climate_matrix: ClimateMatrix,
+    preferred_day_temperature: np.float32,
+    summer_heat_limit: np.float32,
+    winter_cold_limit: np.float32,
+) -> NDArray[np.float32]:
+    """Score the temperature constraints while reusing temporary buffers."""
+    ideal_scores = np.empty_like(climate_matrix.typical_highs_c)
+    np.subtract(climate_matrix.typical_highs_c, preferred_day_temperature, out=ideal_scores)
+    np.absolute(ideal_scores, out=ideal_scores)
+    np.subtract(ideal_scores, TEMPERATURE_COMFORT_BAND_C, out=ideal_scores)
+    np.clip(ideal_scores, 0.0, None, out=ideal_scores)
+    np.divide(ideal_scores, TEMPERATURE_IDEAL_SLOPE_C, out=ideal_scores)
+    np.subtract(1.0, ideal_scores, out=ideal_scores)
+    np.clip(ideal_scores, 0.0, 1.0, out=ideal_scores)
+
+    heat_scores = np.empty_like(climate_matrix.hottest_month_highs_c)
+    np.subtract(climate_matrix.hottest_month_highs_c, summer_heat_limit, out=heat_scores)
+    np.clip(heat_scores, 0.0, None, out=heat_scores)
+    np.divide(heat_scores, TEMPERATURE_LIMIT_SLOPE_C, out=heat_scores)
+    np.subtract(1.0, heat_scores, out=heat_scores)
+    np.clip(heat_scores, 0.0, 1.0, out=heat_scores)
+
+    cold_scores = np.empty_like(climate_matrix.coldest_month_lows_c)
+    np.subtract(winter_cold_limit, climate_matrix.coldest_month_lows_c, out=cold_scores)
+    np.clip(cold_scores, 0.0, None, out=cold_scores)
+    np.divide(cold_scores, TEMPERATURE_LIMIT_SLOPE_C, out=cold_scores)
+    np.subtract(1.0, cold_scores, out=cold_scores)
+    np.clip(cold_scores, 0.0, 1.0, out=cold_scores)
+
+    np.power(ideal_scores, TEMPERATURE_IDEAL_WEIGHT, out=ideal_scores)
+    np.power(heat_scores, TEMPERATURE_HEAT_WEIGHT, out=heat_scores)
+    np.multiply(ideal_scores, heat_scores, out=ideal_scores)
+    np.power(cold_scores, TEMPERATURE_COLD_WEIGHT, out=cold_scores)
+    np.multiply(ideal_scores, cold_scores, out=ideal_scores)
+    return ideal_scores
+
+
 STUB_CLIMATE_CELLS: tuple[ClimateCell, ...] = (
     ClimateCell(
         lat=37.5,
@@ -537,19 +575,12 @@ def score_climate_matrix(
         timings.setup_ms = (perf_counter() - setup_started) * 1000
 
     temperature_started = perf_counter()
-    ideal_distance = np.maximum(
-        np.abs(climate_matrix.typical_highs_c - preferred_day_temperature) - TEMPERATURE_COMFORT_BAND_C, 0.0
+    temperature_scores = _temperature_score_block(
+        climate_matrix,
+        preferred_day_temperature,
+        summer_heat_limit,
+        winter_cold_limit,
     )
-    ideal_scores = np.clip(1.0 - (ideal_distance / TEMPERATURE_IDEAL_SLOPE_C), 0.0, 1.0)
-    heat_excess = np.maximum(climate_matrix.hottest_month_highs_c - summer_heat_limit, 0.0)
-    heat_scores = np.clip(1.0 - (heat_excess / TEMPERATURE_LIMIT_SLOPE_C), 0.0, 1.0)
-    cold_excess = np.maximum(winter_cold_limit - climate_matrix.coldest_month_lows_c, 0.0)
-    cold_scores = np.clip(1.0 - (cold_excess / TEMPERATURE_LIMIT_SLOPE_C), 0.0, 1.0)
-    temperature_scores = (
-        ideal_scores**TEMPERATURE_IDEAL_WEIGHT
-        * heat_scores**TEMPERATURE_HEAT_WEIGHT
-        * cold_scores**TEMPERATURE_COLD_WEIGHT
-    ).astype(np.float32, copy=False)
     if timings is not None:
         timings.temperature_ms = (perf_counter() - temperature_started) * 1000
 

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -590,7 +590,10 @@ def score_climate_matrix(
     *,
     timings: MatrixScoreTimings | None = None,
 ) -> NDArray[np.float32]:
-    """Score the compact climate matrix with vectorized NumPy operations."""
+    """Score the compact climate matrix with vectorized NumPy operations.
+
+    If provided, ``timings`` is populated in place with per-phase cold-path timings.
+    """
     setup_started = perf_counter()
     tolerated_cloud_cover = MAX_TOLERATED_CLOUD_COVER - (
         (MAX_TOLERATED_CLOUD_COVER - MIN_TOLERATED_CLOUD_COVER) * (preferences.sunshine_preference / 100.0)

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -32,6 +32,19 @@ PRECIPITATION_PROFILE_PEAK_WEIGHT = 0.3
 SUN_PROFILE_AVERAGE_WEIGHT = 0.7
 SUN_PROFILE_GLOOM_WEIGHT = 0.3
 MULTIPLICATIVE_SCORE_FLOOR = 0.02
+TEMPERATURE_COMFORT_BAND_C32 = np.float32(TEMPERATURE_COMFORT_BAND_C)
+TEMPERATURE_IDEAL_SLOPE_C32 = np.float32(TEMPERATURE_IDEAL_SLOPE_C)
+TEMPERATURE_LIMIT_SLOPE_C32 = np.float32(TEMPERATURE_LIMIT_SLOPE_C)
+TEMPERATURE_IDEAL_WEIGHT32 = np.float32(TEMPERATURE_IDEAL_WEIGHT)
+TEMPERATURE_HEAT_WEIGHT32 = np.float32(TEMPERATURE_HEAT_WEIGHT)
+TEMPERATURE_COLD_WEIGHT32 = np.float32(TEMPERATURE_COLD_WEIGHT)
+SATURATING_MONTHLY_RAIN_MM32 = np.float32(SATURATING_MONTHLY_RAIN_MM)
+SATURATING_WETTEST_MONTH_RAIN_MM32 = np.float32(SATURATING_WETTEST_MONTH_RAIN_MM)
+PRECIPITATION_PROFILE_MEDIAN_WEIGHT32 = np.float32(PRECIPITATION_PROFILE_MEDIAN_WEIGHT)
+PRECIPITATION_PROFILE_PEAK_WEIGHT32 = np.float32(PRECIPITATION_PROFILE_PEAK_WEIGHT)
+SUN_PROFILE_AVERAGE_WEIGHT32 = np.float32(SUN_PROFILE_AVERAGE_WEIGHT)
+SUN_PROFILE_GLOOM_WEIGHT32 = np.float32(SUN_PROFILE_GLOOM_WEIGHT)
+MULTIPLICATIVE_SCORE_FLOOR32 = np.float32(MULTIPLICATIVE_SCORE_FLOOR)
 
 
 class PreferenceInputs(BaseModel):
@@ -305,7 +318,7 @@ def _combine_score_blocks(
     np.multiply(preference_scores, scores, out=preference_scores)
 
     np.power(temperature_scores, temperature_weight, out=scores)
-    np.power(preference_scores, 1 - temperature_weight, out=preference_scores)
+    np.power(preference_scores, np.float32(1.0) - temperature_weight, out=preference_scores)
     np.multiply(scores, preference_scores, out=scores)
     np.clip(scores, 0.0, 1.0, out=scores)
     return scores
@@ -321,30 +334,30 @@ def _temperature_score_block(
     ideal_scores = np.empty_like(climate_matrix.typical_highs_c)
     np.subtract(climate_matrix.typical_highs_c, preferred_day_temperature, out=ideal_scores)
     np.absolute(ideal_scores, out=ideal_scores)
-    np.subtract(ideal_scores, TEMPERATURE_COMFORT_BAND_C, out=ideal_scores)
+    np.subtract(ideal_scores, TEMPERATURE_COMFORT_BAND_C32, out=ideal_scores)
     np.clip(ideal_scores, 0.0, None, out=ideal_scores)
-    np.divide(ideal_scores, TEMPERATURE_IDEAL_SLOPE_C, out=ideal_scores)
+    np.divide(ideal_scores, TEMPERATURE_IDEAL_SLOPE_C32, out=ideal_scores)
     np.subtract(1.0, ideal_scores, out=ideal_scores)
     np.clip(ideal_scores, 0.0, 1.0, out=ideal_scores)
 
     heat_scores = np.empty_like(climate_matrix.hottest_month_highs_c)
     np.subtract(climate_matrix.hottest_month_highs_c, summer_heat_limit, out=heat_scores)
     np.clip(heat_scores, 0.0, None, out=heat_scores)
-    np.divide(heat_scores, TEMPERATURE_LIMIT_SLOPE_C, out=heat_scores)
+    np.divide(heat_scores, TEMPERATURE_LIMIT_SLOPE_C32, out=heat_scores)
     np.subtract(1.0, heat_scores, out=heat_scores)
     np.clip(heat_scores, 0.0, 1.0, out=heat_scores)
 
     cold_scores = np.empty_like(climate_matrix.coldest_month_lows_c)
     np.subtract(winter_cold_limit, climate_matrix.coldest_month_lows_c, out=cold_scores)
     np.clip(cold_scores, 0.0, None, out=cold_scores)
-    np.divide(cold_scores, TEMPERATURE_LIMIT_SLOPE_C, out=cold_scores)
+    np.divide(cold_scores, TEMPERATURE_LIMIT_SLOPE_C32, out=cold_scores)
     np.subtract(1.0, cold_scores, out=cold_scores)
     np.clip(cold_scores, 0.0, 1.0, out=cold_scores)
 
-    np.power(ideal_scores, TEMPERATURE_IDEAL_WEIGHT, out=ideal_scores)
-    np.power(heat_scores, TEMPERATURE_HEAT_WEIGHT, out=heat_scores)
+    np.power(ideal_scores, TEMPERATURE_IDEAL_WEIGHT32, out=ideal_scores)
+    np.power(heat_scores, TEMPERATURE_HEAT_WEIGHT32, out=heat_scores)
     np.multiply(ideal_scores, heat_scores, out=ideal_scores)
-    np.power(cold_scores, TEMPERATURE_COLD_WEIGHT, out=cold_scores)
+    np.power(cold_scores, TEMPERATURE_COLD_WEIGHT32, out=cold_scores)
     np.multiply(ideal_scores, cold_scores, out=ideal_scores)
     return ideal_scores
 
@@ -352,19 +365,19 @@ def _temperature_score_block(
 def _rain_score_block(climate_matrix: ClimateMatrix, dryness_ratio: np.float32) -> NDArray[np.float32]:
     """Score the precipitation constraints while reusing temporary buffers."""
     typical_rain_scores = np.empty_like(climate_matrix.median_precipitation_mm)
-    np.divide(climate_matrix.median_precipitation_mm, SATURATING_MONTHLY_RAIN_MM, out=typical_rain_scores)
+    np.divide(climate_matrix.median_precipitation_mm, SATURATING_MONTHLY_RAIN_MM32, out=typical_rain_scores)
     np.multiply(typical_rain_scores, dryness_ratio, out=typical_rain_scores)
     np.subtract(1.0, typical_rain_scores, out=typical_rain_scores)
-    np.clip(typical_rain_scores, MULTIPLICATIVE_SCORE_FLOOR, 1.0, out=typical_rain_scores)
+    np.clip(typical_rain_scores, MULTIPLICATIVE_SCORE_FLOOR32, 1.0, out=typical_rain_scores)
 
     wettest_month_scores = np.empty_like(climate_matrix.wettest_precipitation_mm)
-    np.divide(climate_matrix.wettest_precipitation_mm, SATURATING_WETTEST_MONTH_RAIN_MM, out=wettest_month_scores)
+    np.divide(climate_matrix.wettest_precipitation_mm, SATURATING_WETTEST_MONTH_RAIN_MM32, out=wettest_month_scores)
     np.multiply(wettest_month_scores, dryness_ratio, out=wettest_month_scores)
     np.subtract(1.0, wettest_month_scores, out=wettest_month_scores)
-    np.clip(wettest_month_scores, MULTIPLICATIVE_SCORE_FLOOR, 1.0, out=wettest_month_scores)
+    np.clip(wettest_month_scores, MULTIPLICATIVE_SCORE_FLOOR32, 1.0, out=wettest_month_scores)
 
-    np.power(typical_rain_scores, PRECIPITATION_PROFILE_MEDIAN_WEIGHT, out=typical_rain_scores)
-    np.power(wettest_month_scores, PRECIPITATION_PROFILE_PEAK_WEIGHT, out=wettest_month_scores)
+    np.power(typical_rain_scores, PRECIPITATION_PROFILE_MEDIAN_WEIGHT32, out=typical_rain_scores)
+    np.power(wettest_month_scores, PRECIPITATION_PROFILE_PEAK_WEIGHT32, out=wettest_month_scores)
     np.multiply(typical_rain_scores, wettest_month_scores, out=typical_rain_scores)
     return typical_rain_scores
 
@@ -618,7 +631,7 @@ def score_climate_matrix(
     np.divide(average_excess_ratio, cloud_denominator, out=average_excess_ratio)
     np.clip(average_excess_ratio, 0.0, None, out=average_excess_ratio)
     average_sun_scores = np.subtract(1.0, average_excess_ratio * average_excess_ratio, dtype=np.float32)
-    np.clip(average_sun_scores, MULTIPLICATIVE_SCORE_FLOOR, 1.0, out=average_sun_scores)
+    np.clip(average_sun_scores, MULTIPLICATIVE_SCORE_FLOOR32, 1.0, out=average_sun_scores)
 
     gloom_excess_ratio = np.subtract(
         climate_matrix.gloomiest_cloud_cover_pct.astype(np.float32, copy=False),
@@ -628,10 +641,10 @@ def score_climate_matrix(
     np.divide(gloom_excess_ratio, cloud_denominator, out=gloom_excess_ratio)
     np.clip(gloom_excess_ratio, 0.0, None, out=gloom_excess_ratio)
     gloomiest_sun_scores = np.subtract(1.0, gloom_excess_ratio * gloom_excess_ratio, dtype=np.float32)
-    np.clip(gloomiest_sun_scores, MULTIPLICATIVE_SCORE_FLOOR, 1.0, out=gloomiest_sun_scores)
+    np.clip(gloomiest_sun_scores, MULTIPLICATIVE_SCORE_FLOOR32, 1.0, out=gloomiest_sun_scores)
 
     sun_scores = (
-        average_sun_scores**SUN_PROFILE_AVERAGE_WEIGHT * gloomiest_sun_scores**SUN_PROFILE_GLOOM_WEIGHT
+        average_sun_scores**SUN_PROFILE_AVERAGE_WEIGHT32 * gloomiest_sun_scores**SUN_PROFILE_GLOOM_WEIGHT32
     ).astype(
         np.float32,
         copy=False,

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -660,7 +660,10 @@ def normalize_score_array(scores: NDArray[np.float32]) -> NDArray[np.float32]:
     if max_score == 0.0:
         return scores
 
-    return np.round(scores / max_score, 4).astype(np.float32, copy=False)
+    normalized_scores = scores.copy()
+    np.divide(normalized_scores, np.float32(max_score), out=normalized_scores)
+    np.round(normalized_scores, 4, out=normalized_scores)
+    return normalized_scores
 
 
 def score_matrix_row_breakdown(

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -349,6 +349,26 @@ def _temperature_score_block(
     return ideal_scores
 
 
+def _rain_score_block(climate_matrix: ClimateMatrix, dryness_ratio: np.float32) -> NDArray[np.float32]:
+    """Score the precipitation constraints while reusing temporary buffers."""
+    typical_rain_scores = np.empty_like(climate_matrix.median_precipitation_mm)
+    np.divide(climate_matrix.median_precipitation_mm, SATURATING_MONTHLY_RAIN_MM, out=typical_rain_scores)
+    np.multiply(typical_rain_scores, dryness_ratio, out=typical_rain_scores)
+    np.subtract(1.0, typical_rain_scores, out=typical_rain_scores)
+    np.clip(typical_rain_scores, MULTIPLICATIVE_SCORE_FLOOR, 1.0, out=typical_rain_scores)
+
+    wettest_month_scores = np.empty_like(climate_matrix.wettest_precipitation_mm)
+    np.divide(climate_matrix.wettest_precipitation_mm, SATURATING_WETTEST_MONTH_RAIN_MM, out=wettest_month_scores)
+    np.multiply(wettest_month_scores, dryness_ratio, out=wettest_month_scores)
+    np.subtract(1.0, wettest_month_scores, out=wettest_month_scores)
+    np.clip(wettest_month_scores, MULTIPLICATIVE_SCORE_FLOOR, 1.0, out=wettest_month_scores)
+
+    np.power(typical_rain_scores, PRECIPITATION_PROFILE_MEDIAN_WEIGHT, out=typical_rain_scores)
+    np.power(wettest_month_scores, PRECIPITATION_PROFILE_PEAK_WEIGHT, out=wettest_month_scores)
+    np.multiply(typical_rain_scores, wettest_month_scores, out=typical_rain_scores)
+    return typical_rain_scores
+
+
 STUB_CLIMATE_CELLS: tuple[ClimateCell, ...] = (
     ClimateCell(
         lat=37.5,
@@ -585,20 +605,7 @@ def score_climate_matrix(
         timings.temperature_ms = (perf_counter() - temperature_started) * 1000
 
     rain_started = perf_counter()
-    typical_rain_scores = np.clip(
-        1.0 - (climate_matrix.median_precipitation_mm / SATURATING_MONTHLY_RAIN_MM) * dryness_ratio,
-        0.0,
-        1.0,
-    )
-    wettest_month_scores = np.clip(
-        1.0 - (climate_matrix.wettest_precipitation_mm / SATURATING_WETTEST_MONTH_RAIN_MM) * dryness_ratio,
-        0.0,
-        1.0,
-    )
-    rain_scores = (
-        np.maximum(typical_rain_scores, MULTIPLICATIVE_SCORE_FLOOR) ** PRECIPITATION_PROFILE_MEDIAN_WEIGHT
-        * np.maximum(wettest_month_scores, MULTIPLICATIVE_SCORE_FLOOR) ** PRECIPITATION_PROFILE_PEAK_WEIGHT
-    ).astype(np.float32, copy=False)
+    rain_scores = _rain_score_block(climate_matrix, dryness_ratio)
     if timings is not None:
         timings.rain_ms = (perf_counter() - rain_started) * 1000
 

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -290,6 +290,27 @@ class MatrixScoreTimings:
     combine_ms: float = 0.0
 
 
+def _combine_score_blocks(
+    temperature_scores: NDArray[np.float32],
+    rain_scores: NDArray[np.float32],
+    sun_scores: NDArray[np.float32],
+    weights: tuple[float, float, float],
+) -> NDArray[np.float32]:
+    """Combine precomputed score blocks while reusing temporary buffers."""
+    temperature_weight, rain_weight, sun_weight = weights
+    preference_scores = np.empty_like(rain_scores)
+    np.power(rain_scores, rain_weight, out=preference_scores)
+    scores = np.empty_like(sun_scores)
+    np.power(sun_scores, sun_weight, out=scores)
+    np.multiply(preference_scores, scores, out=preference_scores)
+
+    np.power(temperature_scores, temperature_weight, out=scores)
+    np.power(preference_scores, 1 - temperature_weight, out=preference_scores)
+    np.multiply(scores, preference_scores, out=scores)
+    np.clip(scores, 0.0, 1.0, out=scores)
+    return scores
+
+
 STUB_CLIMATE_CELLS: tuple[ClimateCell, ...] = (
     ClimateCell(
         lat=37.5,
@@ -581,12 +602,12 @@ def score_climate_matrix(
         timings.sun_ms = (perf_counter() - sun_started) * 1000
 
     combine_started = perf_counter()
-    preference_scores = (rain_scores**rain_weight * sun_scores**sun_weight).astype(np.float32, copy=False)
-    scores = np.clip(
-        temperature_scores**temperature_weight * preference_scores ** (1 - temperature_weight),
-        0.0,
-        1.0,
-    ).astype(np.float32, copy=False)
+    scores = _combine_score_blocks(
+        temperature_scores,
+        rain_scores,
+        sun_scores,
+        (temperature_weight, rain_weight, sun_weight),
+    )
     if timings is not None:
         timings.combine_ms = (perf_counter() - combine_started) * 1000
     return scores

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -1092,10 +1092,10 @@ def test_test_endpoint_runs_smoke_suite_without_heatmap() -> None:
 
     assert payload["suite"] == "smoke"
     assert payload["include_heatmap"] is False
+    assert payload["use_cache"] is False
     assert payload["case_count"] == 1
     assert payload["elapsed_ms"] >= 0
-    assert payload["results"][0]["duplicate_run"] is True
-    assert len(payload["results"][0]["score_cache_statuses"]) == 2
+    assert payload["results"][0]["score_cache_statuses"] == ["bypass"]
 
 
 def test_probe_endpoint_rejects_typical_day_above_summer_limit() -> None:

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -1084,20 +1084,6 @@ def test_score_endpoint_accepts_mild_winter_limit_above_20_when_ordered() -> Non
     assert response.status_code == 200
 
 
-def test_test_endpoint_runs_smoke_suite_without_heatmap() -> None:
-    response = client.get("/test", params={"suite": "smoke", "include_heatmap": False})
-
-    assert response.status_code == 200
-    payload = response.json()
-
-    assert payload["suite"] == "smoke"
-    assert payload["include_heatmap"] is False
-    assert payload["use_cache"] is False
-    assert payload["case_count"] == 1
-    assert payload["elapsed_ms"] >= 0
-    assert payload["results"][0]["score_cache_statuses"] == ["bypass"]
-
-
 def test_probe_endpoint_rejects_typical_day_above_summer_limit() -> None:
     response = client.get(
         "/probe",

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -866,7 +866,11 @@ def test_heatmap_endpoint_reuses_score_field_from_prior_score_request(monkeypatc
         "sunshine_preference": "85",
     }
 
-    def counted_score_matrix(climate_matrix: ClimateMatrix, preferences: PreferenceInputs) -> np.ndarray:
+    def counted_score_matrix(
+        climate_matrix: ClimateMatrix,
+        preferences: PreferenceInputs,
+        **_kwargs: object,
+    ) -> np.ndarray:
         nonlocal score_calls
         score_calls += 1
         return original_score_matrix(climate_matrix, preferences)

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -1084,6 +1084,20 @@ def test_score_endpoint_accepts_mild_winter_limit_above_20_when_ordered() -> Non
     assert response.status_code == 200
 
 
+def test_test_endpoint_runs_smoke_suite_without_heatmap() -> None:
+    response = client.get("/test", params={"suite": "smoke", "include_heatmap": False})
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["suite"] == "smoke"
+    assert payload["include_heatmap"] is False
+    assert payload["case_count"] == 1
+    assert payload["elapsed_ms"] >= 0
+    assert payload["results"][0]["duplicate_run"] is True
+    assert len(payload["results"][0]["score_cache_statuses"]) == 2
+
+
 def test_probe_endpoint_rejects_typical_day_above_summer_limit() -> None:
     response = client.get(
         "/probe",

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import threading
 import time
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 import numpy as np
@@ -721,7 +721,10 @@ def test_score_endpoint_logs_cache_hit_and_miss_route_details(monkeypatch: Monke
 
     assert default_event["event"] == "score_request_route"
     assert default_event["cache_hit"] is True
+    assert default_event["cache_status"] == "hit"
     assert cast("float", default_event["queue_wait_ms"]) >= 0
+    assert cast("int", default_event["score_queue_depth"]) >= 0
+    assert cast("int", default_event["score_inflight"]) >= 1
     assert default_event["preferred_day_temperature"] == 18
     assert default_event["summer_heat_limit"] == 30
     assert default_event["winter_cold_limit"] == 0
@@ -730,7 +733,10 @@ def test_score_endpoint_logs_cache_hit_and_miss_route_details(monkeypatch: Monke
 
     assert custom_event["event"] == "score_request_route"
     assert custom_event["cache_hit"] is False
+    assert custom_event["cache_status"] == "miss_built"
     assert cast("float", custom_event["queue_wait_ms"]) >= 0
+    assert cast("int", custom_event["score_queue_depth"]) >= 0
+    assert cast("int", custom_event["score_inflight"]) >= 1
     assert custom_event["preferred_day_temperature"] == 22
     assert custom_event["summer_heat_limit"] == 30
     assert custom_event["winter_cold_limit"] == 5
@@ -882,7 +888,7 @@ def test_score_response_cache_deduplicates_concurrent_identical_misses() -> None
     key = (18, 30, 0, 30, 50)
     build_started = threading.Event()
     build_count = 0
-    results: list[dict[str, object]] = []
+    results: list[Any] = []
 
     def build() -> dict[str, object]:
         nonlocal build_count
@@ -892,7 +898,7 @@ def test_score_response_cache_deduplicates_concurrent_identical_misses() -> None
         return {"scores": []}
 
     def worker() -> None:
-        results.append(cache.get_or_set(key, build))
+        results.append(cache.get_with_status_or_set(key, build))
 
     threads = [threading.Thread(target=worker), threading.Thread(target=worker)]
     threads[0].start()
@@ -903,7 +909,8 @@ def test_score_response_cache_deduplicates_concurrent_identical_misses() -> None
         assert not thread.is_alive()
 
     assert build_count == 1
-    assert results == [{"scores": []}, {"scores": []}]
+    assert [result.response for result in results] == [{"scores": []}, {"scores": []}]
+    assert sorted(result.cache_status for result in results) == ["miss_built", "miss_waited"]
 
 
 def test_score_response_cache_recovers_after_failing_inflight_build() -> None:
@@ -913,7 +920,7 @@ def test_score_response_cache_recovers_after_failing_inflight_build() -> None:
     build_started = threading.Event()
     call_count = 0
     failures: list[str] = []
-    successes: list[dict[str, object]] = []
+    successes: list[Any] = []
 
     def flaky_build() -> dict[str, object]:
         nonlocal call_count
@@ -927,7 +934,7 @@ def test_score_response_cache_recovers_after_failing_inflight_build() -> None:
 
     def worker() -> None:
         try:
-            successes.append(cache.get_or_set(key, flaky_build))
+            successes.append(cache.get_with_status_or_set(key, flaky_build))
         except RuntimeError as error:
             failures.append(str(error))
 
@@ -940,7 +947,8 @@ def test_score_response_cache_recovers_after_failing_inflight_build() -> None:
         assert not thread.is_alive()
 
     assert failures == ["boom"]
-    assert successes == [{"scores": []}]
+    assert [result.response for result in successes] == [{"scores": []}]
+    assert [result.cache_status for result in successes] == ["miss_built"]
     assert call_count == 2
     assert cache.get_or_set(key, flaky_build) == {"scores": []}
     assert call_count == 2

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -520,7 +520,7 @@ def test_score_endpoint_offloads_scoring_to_threadpool(monkeypatch: MonkeyPatch)
 
 
 @pytest.mark.anyio
-async def test_score_endpoint_serializes_concurrent_requests_per_worker() -> None:
+async def test_score_endpoint_allows_two_concurrent_requests_per_worker() -> None:
     entered = threading.Event()
     release_first = threading.Event()
     second_entered = threading.Event()
@@ -553,7 +553,7 @@ async def test_score_endpoint_serializes_concurrent_requests_per_worker() -> Non
 
             second_request = asyncio.create_task(async_client.post("/score", data=default_form_data()))
             await asyncio.sleep(0.05)
-            assert not second_entered.is_set()
+            assert second_entered.is_set()
 
             release_first.set()
 
@@ -568,7 +568,7 @@ async def test_score_endpoint_serializes_concurrent_requests_per_worker() -> Non
 
 
 @pytest.mark.anyio
-async def test_score_endpoint_releases_semaphore_after_failed_request() -> None:
+async def test_score_endpoint_keeps_second_slot_available_after_failed_request() -> None:
     entered = threading.Event()
     release_first = threading.Event()
     second_entered = threading.Event()
@@ -602,7 +602,7 @@ async def test_score_endpoint_releases_semaphore_after_failed_request() -> None:
 
             second_request = asyncio.create_task(async_client.post("/score", data=default_form_data()))
             await asyncio.sleep(0.05)
-            assert not second_entered.is_set()
+            assert second_entered.is_set()
 
             release_first.set()
 

--- a/tests/test_cities.py
+++ b/tests/test_cities.py
@@ -155,6 +155,7 @@ def test_rank_indexed_city_scores_matches_classic_ranking_behavior() -> None:
     indexed_catalog = CityRankingCache(
         cities=cities,
         climate_indexes=np.array([0, 1, 2], dtype=np.int32),
+        populations=np.array([max(city.population, 0) for city in cities], dtype=np.int32),
         latitude_radians=np.radians(np.array([city.lat for city in cities], dtype=np.float32)),
         longitude_radians=np.radians(np.array([city.lon for city in cities], dtype=np.float32)),
         sine_latitudes=np.sin(np.radians(np.array([city.lat for city in cities], dtype=np.float32))).astype(
@@ -238,6 +239,7 @@ def test_rank_indexed_city_scores_prefers_larger_population_center_when_scores_a
     indexed_catalog = CityRankingCache(
         cities=cities,
         climate_indexes=np.array([0, 1], dtype=np.int32),
+        populations=np.array([max(city.population, 0) for city in cities], dtype=np.int32),
         latitude_radians=np.radians(np.array([city.lat for city in cities], dtype=np.float32)),
         longitude_radians=np.radians(np.array([city.lon for city in cities], dtype=np.float32)),
         sine_latitudes=np.sin(np.radians(np.array([city.lat for city in cities], dtype=np.float32))).astype(

--- a/tests/test_cities.py
+++ b/tests/test_cities.py
@@ -157,7 +157,19 @@ def test_rank_indexed_city_scores_matches_classic_ranking_behavior() -> None:
         climate_indexes=np.array([0, 1, 2], dtype=np.int32),
         latitude_radians=np.radians(np.array([city.lat for city in cities], dtype=np.float32)),
         longitude_radians=np.radians(np.array([city.lon for city in cities], dtype=np.float32)),
+        sine_latitudes=np.sin(np.radians(np.array([city.lat for city in cities], dtype=np.float32))).astype(
+            np.float32,
+            copy=False,
+        ),
         cosine_latitudes=np.cos(np.radians(np.array([city.lat for city in cities], dtype=np.float32))).astype(
+            np.float32,
+            copy=False,
+        ),
+        sine_longitudes=np.sin(np.radians(np.array([city.lon for city in cities], dtype=np.float32))).astype(
+            np.float32,
+            copy=False,
+        ),
+        cosine_longitudes=np.cos(np.radians(np.array([city.lon for city in cities], dtype=np.float32))).astype(
             np.float32,
             copy=False,
         ),
@@ -228,7 +240,19 @@ def test_rank_indexed_city_scores_prefers_larger_population_center_when_scores_a
         climate_indexes=np.array([0, 1], dtype=np.int32),
         latitude_radians=np.radians(np.array([city.lat for city in cities], dtype=np.float32)),
         longitude_radians=np.radians(np.array([city.lon for city in cities], dtype=np.float32)),
+        sine_latitudes=np.sin(np.radians(np.array([city.lat for city in cities], dtype=np.float32))).astype(
+            np.float32,
+            copy=False,
+        ),
         cosine_latitudes=np.cos(np.radians(np.array([city.lat for city in cities], dtype=np.float32))).astype(
+            np.float32,
+            copy=False,
+        ),
+        sine_longitudes=np.sin(np.radians(np.array([city.lon for city in cities], dtype=np.float32))).astype(
+            np.float32,
+            copy=False,
+        ),
+        cosine_longitudes=np.cos(np.radians(np.array([city.lon for city in cities], dtype=np.float32))).astype(
             np.float32,
             copy=False,
         ),

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -9,7 +9,6 @@ from backend.heatmap import (
     HeatmapProjection,
     _expand_detail_source,
     _preserve_local_maxima,
-    _smooth_styled_heatmap_gray,
     _stylize_heatmap_gray,
     render_heatmap_png_from_arrays,
     render_heatmap_png_from_projection,
@@ -133,18 +132,3 @@ def test_stylize_heatmap_gray_quantizes_to_limited_band_values() -> None:
     assert np.all(np.diff(styled[0].astype(np.int16)) >= 0)
     assert styled[0, 2] < gray[0, 2]
     assert styled[0, -1] == 255
-
-
-def test_smooth_styled_heatmap_gray_softens_isolated_speckle() -> None:
-    gray = np.array(
-        [
-            [0, 0, 0],
-            [0, 255, 0],
-            [0, 0, 0],
-        ],
-        dtype=np.uint8,
-    )
-
-    smoothed = _smooth_styled_heatmap_gray(gray)
-
-    assert smoothed[1, 1] == 255

--- a/tests/test_score_service.py
+++ b/tests/test_score_service.py
@@ -61,6 +61,10 @@ def test_build_score_response_logs_step_timings(caplog: LogCaptureFixture) -> No
     assert cast("float", record.__dict__["scoring_ms"]) >= 0
     assert cast("float", record.__dict__["normalize_ms"]) >= 0
     assert cast("float", record.__dict__["ranking_ms"]) >= 0
+    assert cast("float", record.__dict__["ranking_filter_ms"]) >= 0
+    assert cast("float", record.__dict__["ranking_candidates_ms"]) >= 0
+    assert cast("float", record.__dict__["ranking_sidebar_ms"]) >= 0
+    assert cast("float", record.__dict__["ranking_rescore_ms"]) >= 0
     assert record.__dict__["heatmap_ms"] == 0.0
     assert cast("float", record.__dict__["response_ms"]) >= 0
     assert record.__dict__["preferred_day_temperature"] == preferences.preferred_day_temperature

--- a/tests/test_score_service.py
+++ b/tests/test_score_service.py
@@ -59,10 +59,19 @@ def test_build_score_response_logs_step_timings(caplog: LogCaptureFixture) -> No
     assert cast("float", record.__dict__["cells_ms"]) >= 0
     assert cast("float", record.__dict__["cities_ms"]) >= 0
     assert cast("float", record.__dict__["scoring_ms"]) >= 0
+    assert cast("float", record.__dict__["scoring_setup_ms"]) >= 0
+    assert cast("float", record.__dict__["scoring_temperature_ms"]) >= 0
+    assert cast("float", record.__dict__["scoring_rain_ms"]) >= 0
+    assert cast("float", record.__dict__["scoring_sun_ms"]) >= 0
+    assert cast("float", record.__dict__["scoring_combine_ms"]) >= 0
     assert cast("float", record.__dict__["normalize_ms"]) >= 0
     assert cast("float", record.__dict__["ranking_ms"]) >= 0
     assert cast("float", record.__dict__["ranking_filter_ms"]) >= 0
     assert cast("float", record.__dict__["ranking_candidates_ms"]) >= 0
+    assert cast("float", record.__dict__["ranking_candidates_setup_ms"]) >= 0
+    assert cast("float", record.__dict__["ranking_candidates_winner_select_ms"]) >= 0
+    assert cast("float", record.__dict__["ranking_candidates_distance_ms"]) >= 0
+    assert cast("float", record.__dict__["ranking_candidates_penalty_ms"]) >= 0
     assert cast("float", record.__dict__["ranking_sidebar_ms"]) >= 0
     assert cast("float", record.__dict__["ranking_rescore_ms"]) >= 0
     assert record.__dict__["heatmap_ms"] == 0.0
@@ -130,7 +139,10 @@ def test_build_score_response_returns_empty_payload_for_all_zero_matrix_scores(m
         def get_indexed_cities(self) -> CityRankingCache:
             return CityRankingCache.from_cities((), np.array([], dtype=np.int32))
 
-    monkeypatch.setattr("backend.score_service.score_climate_matrix", lambda *_args: np.array([0.0], dtype=np.float32))
+    monkeypatch.setattr(
+        "backend.score_service.score_climate_matrix",
+        lambda *_args, **_kwargs: np.array([0.0], dtype=np.float32),
+    )
 
     response = build_score_response(
         cast("ClimateRepository", SingleCellRepository()),


### PR DESCRIPTION
## Summary

Speed up cold `/score` requests by tightening the scoring and ranking hot paths, while keeping the external response contract unchanged.

## What Changed

1. Allow up to two in-flight `/score` requests per worker instead of fully serializing them.
2. Expand `/score` logging with cache status and scoring/ranking phase breakdowns so cold-path bottlenecks are measurable.
3. Rework `score_climate_matrix(...)` to reuse buffers across the temperature, rain, sunshine, combine, and normalize stages.
4. Rework indexed city ranking to reuse precomputed trig/population data and cheaper winner/penalty updates.
5. Shrink the diversified ranking pool to reduce cold ranking cost after benchmarking the tradeoff on this branch.
6. Remove the temporary `/test` profiling endpoint before merge.

## Notes

1. `/score`, `/heatmap`, and `/probe` response shapes stay contract-compatible.
2. Ranked city composition may shift slightly because the ranking candidate pool is tighter than before.
3. The branch keeps the new timing instrumentation because it was needed to drive and validate the optimizations.

## Validation

1. `uv run pytest tests/test_app_shell.py tests/test_score_service.py tests/test_scoring.py tests/test_cities.py tests/test_heatmap.py -q`
2. `uv run ruff check backend/main.py backend/score_service.py backend/scoring.py backend/cities.py tests/test_app_shell.py tests/test_score_service.py tests/test_scoring.py tests/test_cities.py`
3. `uv run ty check backend tests/test_app_shell.py tests/test_score_service.py tests/test_scoring.py tests/test_cities.py tests/test_heatmap.py`
4. Repeated preview benchmark runs against the uncached profile suite via the temporary `/test` harness before it was removed:
   - score-only suite improved from roughly `6936ms` to roughly `4423ms`
   - score+heatmap suite improved from roughly `12222ms` to roughly `10154ms`

Closes #88