### PR TITLE
Trim defensive internal invariant checks

### DIFF
--- a/backend/cities.py
+++ b/backend/cities.py
@@ -363,44 +363,27 @@ class CityRankingCache:
     flags: tuple[str, ...]
 
     def __post_init__(self) -> None:
-        """Reject malformed ranking arrays before they reach the hot path."""
+        """Keep cached ranking arrays aligned with the city tuple."""
         city_count = len(self.cities)
 
         if self.climate_indexes.shape != (city_count,):
-            msg = "climate_indexes must align with cities"
-            raise ValueError(msg)
-
+            raise AssertionError("climate_indexes must align with cities")
         if self.latitude_radians.shape != (city_count,):
-            msg = "latitude_radians must align with cities"
-            raise ValueError(msg)
-
+            raise AssertionError("latitude_radians must align with cities")
         if self.populations.shape != (city_count,):
-            msg = "populations must align with cities"
-            raise ValueError(msg)
-
+            raise AssertionError("populations must align with cities")
         if self.longitude_radians.shape != (city_count,):
-            msg = "longitude_radians must align with cities"
-            raise ValueError(msg)
-
+            raise AssertionError("longitude_radians must align with cities")
         if self.cosine_latitudes.shape != (city_count,):
-            msg = "cosine_latitudes must align with cities"
-            raise ValueError(msg)
-
+            raise AssertionError("cosine_latitudes must align with cities")
         if self.sine_latitudes.shape != (city_count,):
-            msg = "sine_latitudes must align with cities"
-            raise ValueError(msg)
-
+            raise AssertionError("sine_latitudes must align with cities")
         if self.sine_longitudes.shape != (city_count,):
-            msg = "sine_longitudes must align with cities"
-            raise ValueError(msg)
-
+            raise AssertionError("sine_longitudes must align with cities")
         if self.cosine_longitudes.shape != (city_count,):
-            msg = "cosine_longitudes must align with cities"
-            raise ValueError(msg)
-
+            raise AssertionError("cosine_longitudes must align with cities")
         if len(self.flags) != city_count:
-            msg = "flags must align with cities"
-            raise ValueError(msg)
+            raise AssertionError("flags must align with cities")
 
     @classmethod
     def from_cities(

--- a/backend/cities.py
+++ b/backend/cities.py
@@ -362,29 +362,6 @@ class CityRankingCache:
     cosine_longitudes: NDArray[np.float32]
     flags: tuple[str, ...]
 
-    def __post_init__(self) -> None:
-        """Keep cached ranking arrays aligned with the city tuple."""
-        city_count = len(self.cities)
-
-        if self.climate_indexes.shape != (city_count,):
-            raise AssertionError("climate_indexes must align with cities")
-        if self.latitude_radians.shape != (city_count,):
-            raise AssertionError("latitude_radians must align with cities")
-        if self.populations.shape != (city_count,):
-            raise AssertionError("populations must align with cities")
-        if self.longitude_radians.shape != (city_count,):
-            raise AssertionError("longitude_radians must align with cities")
-        if self.cosine_latitudes.shape != (city_count,):
-            raise AssertionError("cosine_latitudes must align with cities")
-        if self.sine_latitudes.shape != (city_count,):
-            raise AssertionError("sine_latitudes must align with cities")
-        if self.sine_longitudes.shape != (city_count,):
-            raise AssertionError("sine_longitudes must align with cities")
-        if self.cosine_longitudes.shape != (city_count,):
-            raise AssertionError("cosine_longitudes must align with cities")
-        if len(self.flags) != city_count:
-            raise AssertionError("flags must align with cities")
-
     @classmethod
     def from_cities(
         cls,

--- a/backend/climate_repository.py
+++ b/backend/climate_repository.py
@@ -162,7 +162,7 @@ class DuckDbClimateRepository:
 
         try:
             return tuple(self._row_to_climate_cell(row) for row in rows)
-        except (AssertionError, TypeError, ValueError) as error:
+        except (TypeError, ValueError) as error:
             msg = f"Failed to map climate data from {self.database_path} into climate rows: {error}"
             raise ClimateDataError(msg) from error
 
@@ -180,7 +180,7 @@ class DuckDbClimateRepository:
 
         try:
             self._cities = tuple(self._row_to_city(row) for row in rows)
-        except (AssertionError, TypeError, ValueError) as error:
+        except (TypeError, ValueError) as error:
             msg = f"Failed to map city data from {self.database_path} into city rows: {error}"
             raise ClimateDataError(msg) from error
 
@@ -207,7 +207,7 @@ class DuckDbClimateRepository:
             wettest_precipitation_mm = np.asarray(columns["wettest_precipitation_mm"], dtype=FLOAT32_DTYPE)
             average_cloud_cover_pct = np.asarray(columns["average_cloud_cover_pct"], dtype=UINT8_DTYPE)
             gloomiest_cloud_cover_pct = np.asarray(columns["gloomiest_cloud_cover_pct"], dtype=UINT8_DTYPE)
-        except (AssertionError, KeyError, TypeError, ValueError) as error:
+        except (KeyError, TypeError, ValueError) as error:
             msg = f"Failed to map climate data from {self.database_path} into climate rows: {error}"
             raise ClimateDataError(msg) from error
 
@@ -286,7 +286,7 @@ class DuckDbClimateRepository:
 
         try:
             return self._row_to_climate_cell(rows[0])
-        except (AssertionError, TypeError, ValueError) as error:
+        except (TypeError, ValueError) as error:
             msg = f"Failed to map climate data from {self.database_path} into climate rows: {error}"
             raise ClimateDataError(msg) from error
 

--- a/backend/climate_repository.py
+++ b/backend/climate_repository.py
@@ -162,7 +162,7 @@ class DuckDbClimateRepository:
 
         try:
             return tuple(self._row_to_climate_cell(row) for row in rows)
-        except (TypeError, ValueError) as error:
+        except (AssertionError, TypeError, ValueError) as error:
             msg = f"Failed to map climate data from {self.database_path} into climate rows: {error}"
             raise ClimateDataError(msg) from error
 
@@ -180,7 +180,7 @@ class DuckDbClimateRepository:
 
         try:
             self._cities = tuple(self._row_to_city(row) for row in rows)
-        except (TypeError, ValueError) as error:
+        except (AssertionError, TypeError, ValueError) as error:
             msg = f"Failed to map city data from {self.database_path} into city rows: {error}"
             raise ClimateDataError(msg) from error
 
@@ -207,7 +207,7 @@ class DuckDbClimateRepository:
             wettest_precipitation_mm = np.asarray(columns["wettest_precipitation_mm"], dtype=FLOAT32_DTYPE)
             average_cloud_cover_pct = np.asarray(columns["average_cloud_cover_pct"], dtype=UINT8_DTYPE)
             gloomiest_cloud_cover_pct = np.asarray(columns["gloomiest_cloud_cover_pct"], dtype=UINT8_DTYPE)
-        except (KeyError, TypeError, ValueError) as error:
+        except (AssertionError, KeyError, TypeError, ValueError) as error:
             msg = f"Failed to map climate data from {self.database_path} into climate rows: {error}"
             raise ClimateDataError(msg) from error
 
@@ -286,7 +286,7 @@ class DuckDbClimateRepository:
 
         try:
             return self._row_to_climate_cell(rows[0])
-        except (TypeError, ValueError) as error:
+        except (AssertionError, TypeError, ValueError) as error:
             msg = f"Failed to map climate data from {self.database_path} into climate rows: {error}"
             raise ClimateDataError(msg) from error
 

--- a/backend/heatmap.py
+++ b/backend/heatmap.py
@@ -34,9 +34,10 @@ PEAK_BOOST_STRENGTH = 1.0
 SCORE_CURVE_GAMMA = 1.35
 _MERCATOR_MAX_RENDER_LATITUDE = MAP_PROJECTION.max_render_latitude
 
-if MAP_PROJECTION.name != "mercator" or _MERCATOR_MAX_RENDER_LATITUDE is None:
-    msg = f"Unsupported heatmap projection: {MAP_PROJECTION.name}"
-    raise ValueError(msg)
+if MAP_PROJECTION.name != "mercator":
+    raise AssertionError(f"Unsupported heatmap projection: {MAP_PROJECTION.name}")
+if _MERCATOR_MAX_RENDER_LATITUDE is None:
+    raise AssertionError(f"Unsupported heatmap projection: {MAP_PROJECTION.name}")
 
 # Mercator y at the maximum latitude, used to normalise y to [0, HEIGHT].
 _Y_MAX = math.log(math.tan(math.pi / 4 + _MERCATOR_MAX_RENDER_LATITUDE * math.pi / 360))

--- a/backend/heatmap.py
+++ b/backend/heatmap.py
@@ -35,9 +35,11 @@ SCORE_CURVE_GAMMA = 1.35
 _MERCATOR_MAX_RENDER_LATITUDE = MAP_PROJECTION.max_render_latitude
 
 if MAP_PROJECTION.name != "mercator":
-    raise AssertionError(f"Unsupported heatmap projection: {MAP_PROJECTION.name}")
+    msg = f"Unsupported heatmap projection: {MAP_PROJECTION.name}"
+    raise RuntimeError(msg)
 if _MERCATOR_MAX_RENDER_LATITUDE is None:
-    raise AssertionError(f"Unsupported heatmap projection: {MAP_PROJECTION.name}")
+    msg = f"Unsupported heatmap projection: {MAP_PROJECTION.name}"
+    raise RuntimeError(msg)
 
 # Mercator y at the maximum latitude, used to normalise y to [0, HEIGHT].
 _Y_MAX = math.log(math.tan(math.pi / 4 + _MERCATOR_MAX_RENDER_LATITUDE * math.pi / 360))

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -82,19 +82,6 @@ class ClimateCell:
     precipitation_mm: tuple[float, ...]
     cloud_cover_pct: tuple[int, ...]
 
-    def __post_init__(self) -> None:
-        """Keep monthly tuples aligned in the internal climate domain model."""
-        if len(self.temperature_c) != MONTHS_PER_YEAR:
-            raise AssertionError("temperature_c must contain 12 monthly values")
-        if len(self.temperature_min_c) != MONTHS_PER_YEAR:
-            raise AssertionError("temperature_min_c must contain 12 monthly values")
-        if len(self.temperature_max_c) != MONTHS_PER_YEAR:
-            raise AssertionError("temperature_max_c must contain 12 monthly values")
-        if len(self.precipitation_mm) != MONTHS_PER_YEAR:
-            raise AssertionError("precipitation_mm must contain 12 monthly values")
-        if len(self.cloud_cover_pct) != MONTHS_PER_YEAR:
-            raise AssertionError("cloud_cover_pct must contain 12 monthly values")
-
 
 @dataclass(frozen=True, slots=True)
 class ClimateMatrix:
@@ -120,115 +107,54 @@ class ClimateMatrix:
     gloomiest_cloud_cover_pct: NDArray[np.uint8] = field(default_factory=lambda: np.array([], dtype=np.uint8))
 
     def __post_init__(self) -> None:
-        """Keep climate-matrix arrays aligned before they reach the scorer."""
-        cell_count = self.latitudes.shape[0]
-
-        self._validate_coordinate_shapes(cell_count)
-
-        if self._has_monthly_inputs():
-            self._validate_base_shapes(cell_count)
+        """Populate derived vectors when full monthly arrays are resident."""
+        if self._has_all_monthly_inputs():
             temperature_min_c = cast("NDArray[np.float32]", self.temperature_min_c)
             temperature_max_c = cast("NDArray[np.float32]", self.temperature_max_c)
             precipitation_mm = cast("NDArray[np.float32]", self.precipitation_mm)
             cloud_cover_pct = cast("NDArray[np.uint8]", self.cloud_cover_pct)
-            self._ensure_derived_vector(
+            self._set_default_derived_vector(
                 "typical_highs_c",
                 np.median(temperature_max_c, axis=1).astype(np.float32, copy=False),
-                cell_count,
             )
-            self._ensure_derived_vector(
+            self._set_default_derived_vector(
                 "hottest_month_highs_c",
                 np.max(temperature_max_c, axis=1).astype(np.float32, copy=False),
-                cell_count,
             )
-            self._ensure_derived_vector(
+            self._set_default_derived_vector(
                 "coldest_month_lows_c",
                 np.min(temperature_min_c, axis=1).astype(np.float32, copy=False),
-                cell_count,
             )
-            self._ensure_derived_vector(
+            self._set_default_derived_vector(
                 "median_precipitation_mm",
                 np.median(precipitation_mm, axis=1).astype(np.float32, copy=False),
-                cell_count,
             )
-            self._ensure_derived_vector(
+            self._set_default_derived_vector(
                 "wettest_precipitation_mm",
                 np.max(precipitation_mm, axis=1).astype(np.float32, copy=False),
-                cell_count,
             )
-            self._ensure_derived_vector(
+            self._set_default_derived_vector(
                 "average_cloud_cover_pct",
                 np.rint(np.mean(cloud_cover_pct.astype(np.float32), axis=1)).astype(np.uint8, copy=False),
-                cell_count,
             )
-            self._ensure_derived_vector(
+            self._set_default_derived_vector(
                 "gloomiest_cloud_cover_pct",
                 np.max(cloud_cover_pct, axis=1).astype(np.uint8, copy=False),
-                cell_count,
             )
-            return
 
-        self._validate_derived_only_shapes(cell_count)
-
-    def _validate_coordinate_shapes(self, cell_count: int) -> None:
-        if self.longitudes.shape != (cell_count,):
-            raise AssertionError("longitudes must align with latitudes")
-
-    def _has_monthly_inputs(self) -> bool:
+    def _has_all_monthly_inputs(self) -> bool:
         monthly_arrays = (
             self.temperature_min_c,
             self.temperature_max_c,
             self.precipitation_mm,
             self.cloud_cover_pct,
         )
-        has_any = any(array is not None for array in monthly_arrays)
-        has_all = all(array is not None for array in monthly_arrays)
-        if has_any and not has_all:
-            raise AssertionError(
-                "temperature_min_c, temperature_max_c, precipitation_mm, and cloud_cover_pct must be provided together"
-            )
-        return has_all
+        return all(array is not None for array in monthly_arrays)
 
-    def _validate_base_shapes(self, cell_count: int) -> None:
-        temperature_min_c = cast("NDArray[np.float32]", self.temperature_min_c)
-        temperature_max_c = cast("NDArray[np.float32]", self.temperature_max_c)
-        precipitation_mm = cast("NDArray[np.float32]", self.precipitation_mm)
-        cloud_cover_pct = cast("NDArray[np.uint8]", self.cloud_cover_pct)
-
-        if self.temperature_c is not None and self.temperature_c.shape != (cell_count, MONTHS_PER_YEAR):
-            raise AssertionError("temperature_c must be shaped (cells, 12)")
-
-        if temperature_min_c.shape != (cell_count, MONTHS_PER_YEAR):
-            raise AssertionError("temperature_min_c must be shaped (cells, 12)")
-        if temperature_max_c.shape != (cell_count, MONTHS_PER_YEAR):
-            raise AssertionError("temperature_max_c must be shaped (cells, 12)")
-        if precipitation_mm.shape != (cell_count, MONTHS_PER_YEAR):
-            raise AssertionError("precipitation_mm must be shaped (cells, 12)")
-        if cloud_cover_pct.shape != (cell_count, MONTHS_PER_YEAR):
-            raise AssertionError("cloud_cover_pct must be shaped (cells, 12)")
-
-    def _validate_derived_only_shapes(self, cell_count: int) -> None:
-        for attribute in (
-            "typical_highs_c",
-            "hottest_month_highs_c",
-            "coldest_month_lows_c",
-            "median_precipitation_mm",
-            "wettest_precipitation_mm",
-            "average_cloud_cover_pct",
-            "gloomiest_cloud_cover_pct",
-        ):
-            current = getattr(self, attribute)
-            if current.shape != (cell_count,):
-                raise AssertionError(f"{attribute} must align with latitudes")
-
-    def _ensure_derived_vector(self, attribute: str, derived: NDArray[np.generic], cell_count: int) -> None:
+    def _set_default_derived_vector(self, attribute: str, derived: NDArray[np.generic]) -> None:
         current = getattr(self, attribute)
         if current.shape == (0,):
             object.__setattr__(self, attribute, derived)
-            return
-
-        if current.shape != (cell_count,):
-            raise AssertionError(f"{attribute} must align with latitudes")
 
     @classmethod
     def from_cells(cls, climate_cells: tuple[ClimateCell, ...]) -> ClimateMatrix:
@@ -667,18 +593,14 @@ def score_matrix_row_breakdown(
     preferences: PreferenceInputs,
 ) -> ProbeBreakdown:
     """Build `/probe` metrics from min/max, rain, and cloud rows without cached mean temperatures."""
-    if climate_matrix.temperature_min_c is None:
-        raise AssertionError("score_matrix_row_breakdown requires monthly climate arrays")
-    if climate_matrix.temperature_max_c is None:
-        raise AssertionError("score_matrix_row_breakdown requires monthly climate arrays")
-    if climate_matrix.precipitation_mm is None:
-        raise AssertionError("score_matrix_row_breakdown requires monthly climate arrays")
-    if climate_matrix.cloud_cover_pct is None:
-        raise AssertionError("score_matrix_row_breakdown requires monthly climate arrays")
+    temperature_min_c = cast("NDArray[np.float32]", climate_matrix.temperature_min_c)
+    temperature_max_c = cast("NDArray[np.float32]", climate_matrix.temperature_max_c)
+    precipitation_mm = cast("NDArray[np.float32]", climate_matrix.precipitation_mm)
+    cloud_cover_pct = cast("NDArray[np.uint8]", climate_matrix.cloud_cover_pct)
 
-    typical_high_value = float(np.median(climate_matrix.temperature_max_c[row_index]))
-    hottest_month_high_value = float(np.max(climate_matrix.temperature_max_c[row_index]))
-    coldest_month_low_value = float(np.min(climate_matrix.temperature_min_c[row_index]))
+    typical_high_value = float(np.median(temperature_max_c[row_index]))
+    hottest_month_high_value = float(np.max(temperature_max_c[row_index]))
+    coldest_month_low_value = float(np.min(temperature_min_c[row_index]))
     typical_high_c = round(typical_high_value, 1)
     hottest_month_high_c = round(hottest_month_high_value, 1)
     coldest_month_low_c = round(coldest_month_low_value, 1)
@@ -688,11 +610,11 @@ def score_matrix_row_breakdown(
         hottest_month_high_value,
         preferences,
     )
-    avg_precip_mm = round(float(np.mean(climate_matrix.precipitation_mm[row_index])), 1)
-    avg_cloud_pct = round(float(np.mean(climate_matrix.cloud_cover_pct[row_index].astype(np.float32))), 1)
+    avg_precip_mm = round(float(np.mean(precipitation_mm[row_index])), 1)
+    avg_cloud_pct = round(float(np.mean(cloud_cover_pct[row_index].astype(np.float32))), 1)
     avg_sun_pct = round(100.0 - avg_cloud_pct, 1)
-    monthly_precipitation = tuple(float(value) for value in climate_matrix.precipitation_mm[row_index])
-    monthly_cloud_cover = tuple(int(value) for value in climate_matrix.cloud_cover_pct[row_index])
+    monthly_precipitation = tuple(float(value) for value in precipitation_mm[row_index])
+    monthly_cloud_cover = tuple(int(value) for value in cloud_cover_pct[row_index])
     temperature_score_value = weighted_product_score(
         (typical_score, TEMPERATURE_IDEAL_WEIGHT),
         (high_score, TEMPERATURE_HEAT_WEIGHT),

--- a/backend/scoring.py
+++ b/backend/scoring.py
@@ -83,26 +83,17 @@ class ClimateCell:
     cloud_cover_pct: tuple[int, ...]
 
     def __post_init__(self) -> None:
-        """Reject incomplete monthly rows before they reach scoring code."""
+        """Keep monthly tuples aligned in the internal climate domain model."""
         if len(self.temperature_c) != MONTHS_PER_YEAR:
-            msg = "temperature_c must contain 12 monthly values"
-            raise ValueError(msg)
-
+            raise AssertionError("temperature_c must contain 12 monthly values")
         if len(self.temperature_min_c) != MONTHS_PER_YEAR:
-            msg = "temperature_min_c must contain 12 monthly values"
-            raise ValueError(msg)
-
+            raise AssertionError("temperature_min_c must contain 12 monthly values")
         if len(self.temperature_max_c) != MONTHS_PER_YEAR:
-            msg = "temperature_max_c must contain 12 monthly values"
-            raise ValueError(msg)
-
+            raise AssertionError("temperature_max_c must contain 12 monthly values")
         if len(self.precipitation_mm) != MONTHS_PER_YEAR:
-            msg = "precipitation_mm must contain 12 monthly values"
-            raise ValueError(msg)
-
+            raise AssertionError("precipitation_mm must contain 12 monthly values")
         if len(self.cloud_cover_pct) != MONTHS_PER_YEAR:
-            msg = "cloud_cover_pct must contain 12 monthly values"
-            raise ValueError(msg)
+            raise AssertionError("cloud_cover_pct must contain 12 monthly values")
 
 
 @dataclass(frozen=True, slots=True)
@@ -129,7 +120,7 @@ class ClimateMatrix:
     gloomiest_cloud_cover_pct: NDArray[np.uint8] = field(default_factory=lambda: np.array([], dtype=np.uint8))
 
     def __post_init__(self) -> None:
-        """Reject malformed matrix shapes before they reach the scorer."""
+        """Keep climate-matrix arrays aligned before they reach the scorer."""
         cell_count = self.latitudes.shape[0]
 
         self._validate_coordinate_shapes(cell_count)
@@ -181,8 +172,7 @@ class ClimateMatrix:
 
     def _validate_coordinate_shapes(self, cell_count: int) -> None:
         if self.longitudes.shape != (cell_count,):
-            msg = "longitudes must align with latitudes"
-            raise ValueError(msg)
+            raise AssertionError("longitudes must align with latitudes")
 
     def _has_monthly_inputs(self) -> bool:
         monthly_arrays = (
@@ -194,10 +184,9 @@ class ClimateMatrix:
         has_any = any(array is not None for array in monthly_arrays)
         has_all = all(array is not None for array in monthly_arrays)
         if has_any and not has_all:
-            msg = (
+            raise AssertionError(
                 "temperature_min_c, temperature_max_c, precipitation_mm, and cloud_cover_pct must be provided together"
             )
-            raise ValueError(msg)
         return has_all
 
     def _validate_base_shapes(self, cell_count: int) -> None:
@@ -207,24 +196,16 @@ class ClimateMatrix:
         cloud_cover_pct = cast("NDArray[np.uint8]", self.cloud_cover_pct)
 
         if self.temperature_c is not None and self.temperature_c.shape != (cell_count, MONTHS_PER_YEAR):
-            msg = "temperature_c must be shaped (cells, 12)"
-            raise ValueError(msg)
+            raise AssertionError("temperature_c must be shaped (cells, 12)")
 
         if temperature_min_c.shape != (cell_count, MONTHS_PER_YEAR):
-            msg = "temperature_min_c must be shaped (cells, 12)"
-            raise ValueError(msg)
-
+            raise AssertionError("temperature_min_c must be shaped (cells, 12)")
         if temperature_max_c.shape != (cell_count, MONTHS_PER_YEAR):
-            msg = "temperature_max_c must be shaped (cells, 12)"
-            raise ValueError(msg)
-
+            raise AssertionError("temperature_max_c must be shaped (cells, 12)")
         if precipitation_mm.shape != (cell_count, MONTHS_PER_YEAR):
-            msg = "precipitation_mm must be shaped (cells, 12)"
-            raise ValueError(msg)
-
+            raise AssertionError("precipitation_mm must be shaped (cells, 12)")
         if cloud_cover_pct.shape != (cell_count, MONTHS_PER_YEAR):
-            msg = "cloud_cover_pct must be shaped (cells, 12)"
-            raise ValueError(msg)
+            raise AssertionError("cloud_cover_pct must be shaped (cells, 12)")
 
     def _validate_derived_only_shapes(self, cell_count: int) -> None:
         for attribute in (
@@ -238,8 +219,7 @@ class ClimateMatrix:
         ):
             current = getattr(self, attribute)
             if current.shape != (cell_count,):
-                msg = f"{attribute} must align with latitudes"
-                raise ValueError(msg)
+                raise AssertionError(f"{attribute} must align with latitudes")
 
     def _ensure_derived_vector(self, attribute: str, derived: NDArray[np.generic], cell_count: int) -> None:
         current = getattr(self, attribute)
@@ -248,8 +228,7 @@ class ClimateMatrix:
             return
 
         if current.shape != (cell_count,):
-            msg = f"{attribute} must align with latitudes"
-            raise ValueError(msg)
+            raise AssertionError(f"{attribute} must align with latitudes")
 
     @classmethod
     def from_cells(cls, climate_cells: tuple[ClimateCell, ...]) -> ClimateMatrix:
@@ -688,14 +667,14 @@ def score_matrix_row_breakdown(
     preferences: PreferenceInputs,
 ) -> ProbeBreakdown:
     """Build `/probe` metrics from min/max, rain, and cloud rows without cached mean temperatures."""
-    if (
-        climate_matrix.temperature_min_c is None
-        or climate_matrix.temperature_max_c is None
-        or climate_matrix.precipitation_mm is None
-        or climate_matrix.cloud_cover_pct is None
-    ):
-        msg = "score_matrix_row_breakdown requires monthly climate arrays"
-        raise ValueError(msg)
+    if climate_matrix.temperature_min_c is None:
+        raise AssertionError("score_matrix_row_breakdown requires monthly climate arrays")
+    if climate_matrix.temperature_max_c is None:
+        raise AssertionError("score_matrix_row_breakdown requires monthly climate arrays")
+    if climate_matrix.precipitation_mm is None:
+        raise AssertionError("score_matrix_row_breakdown requires monthly climate arrays")
+    if climate_matrix.cloud_cover_pct is None:
+        raise AssertionError("score_matrix_row_breakdown requires monthly climate arrays")
 
     typical_high_value = float(np.median(climate_matrix.temperature_max_c[row_index]))
     hottest_month_high_value = float(np.max(climate_matrix.temperature_max_c[row_index]))

--- a/tests/test_climate_repository.py
+++ b/tests/test_climate_repository.py
@@ -25,7 +25,6 @@ from backend.climate_pipeline import (
 from backend.climate_repository import (
     ClimateDataError,
     DuckDbClimateRepository,
-    StubClimateRepository,
 )
 from backend.heatmap import HeatmapProjection
 from backend.main import create_app
@@ -40,24 +39,6 @@ def default_form_data() -> dict[str, str]:
         "dryness_preference": "60",
         "sunshine_preference": "60",
     }
-
-
-def test_stub_climate_repository_returns_climate_cells() -> None:
-    repository = StubClimateRepository()
-
-    cells = repository.list_cells()
-
-    assert cells
-    assert all(isinstance(cell, ClimateCell) for cell in cells)
-
-
-def test_stub_climate_repository_returns_city_candidates() -> None:
-    repository = StubClimateRepository()
-
-    cities = repository.list_cities()
-
-    assert cities
-    assert all(isinstance(city, CityCandidate) for city in cities)
 
 
 def test_duckdb_climate_repository_loads_monthly_climate_rows(tmp_path: Path) -> None:

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -289,7 +289,7 @@ def test_score_matrix_row_breakdown_returns_structured_probe_metrics() -> None:
     assert 0 <= breakdown.overall_score <= 1
     assert [metric.key for metric in breakdown.metrics] == ["temp", "high", "low", "rain", "sun"]
     assert [metric.label for metric in breakdown.metrics] == ["temp", "high", "low", "rain", "sun"]
-    assert all(metric.display_value for metric in breakdown.metrics)
+    assert [metric.display_value for metric in breakdown.metrics] == ["21.0C", "26.0C", "6.0C", "45mm/mo", "64% sun"]
 
 
 def test_score_matrix_row_breakdown_works_without_cached_average_temperatures() -> None:

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -199,32 +199,6 @@ def test_extreme_dryness_preference_increases_rain_impact() -> None:
     assert extreme_gap > neutral_gap
 
 
-@pytest.mark.parametrize(
-    ("field_name", "temperature_c", "precipitation_mm", "cloud_cover_pct"),
-    [
-        ("temperature_c", (20.0,) * 11, (50.0,) * 12, (30,) * 12),
-        ("precipitation_mm", (20.0,) * 12, (50.0,) * 11, (30,) * 12),
-        ("cloud_cover_pct", (20.0,) * 12, (50.0,) * 12, (30,) * 11),
-    ],
-)
-def test_climate_cell_requires_exactly_twelve_months_per_signal(
-    field_name: str,
-    temperature_c: tuple[float, ...],
-    precipitation_mm: tuple[float, ...],
-    cloud_cover_pct: tuple[int, ...],
-) -> None:
-    with pytest.raises(ValueError, match=field_name):
-        ClimateCell(
-            lat=0.0,
-            lon=0.0,
-            temperature_c=temperature_c,
-            temperature_min_c=(10.0,) * 12,
-            temperature_max_c=(20.0,) * 12,
-            precipitation_mm=precipitation_mm,
-            cloud_cover_pct=cloud_cover_pct,
-        )
-
-
 def test_vectorized_scoring_matches_scalar_scoring_for_stub_cells() -> None:
     climate_matrix = ClimateMatrix(
         latitudes=np.array([cell.lat for cell in STUB_CLIMATE_CELLS], dtype=np.float32),
@@ -301,26 +275,6 @@ def test_vectorized_scoring_matches_full_matrix_when_only_derived_vectors_are_re
     )
 
 
-def test_climate_matrix_rejects_partially_populated_monthly_arrays() -> None:
-    with pytest.raises(ValueError, match="must be provided together"):
-        ClimateMatrix(
-            latitudes=np.array([0.0], dtype=np.float32),
-            longitudes=np.array([0.0], dtype=np.float32),
-            temperature_c=None,
-            temperature_min_c=np.array([[10.0] * 12], dtype=np.float32),
-            temperature_max_c=None,
-            precipitation_mm=None,
-            cloud_cover_pct=None,
-            typical_highs_c=np.array([20.0], dtype=np.float32),
-            hottest_month_highs_c=np.array([22.0], dtype=np.float32),
-            coldest_month_lows_c=np.array([8.0], dtype=np.float32),
-            median_precipitation_mm=np.array([15.0], dtype=np.float32),
-            wettest_precipitation_mm=np.array([30.0], dtype=np.float32),
-            average_cloud_cover_pct=np.array([20.0], dtype=np.float32),
-            gloomiest_cloud_cover_pct=np.array([30.0], dtype=np.float32),
-        )
-
-
 def test_normalize_score_array_scales_best_match_to_one() -> None:
     normalized = normalize_score_array(np.array([0.25, 0.5, 0.125], dtype=np.float32))
 
@@ -354,22 +308,3 @@ def test_score_matrix_row_breakdown_works_without_cached_average_temperatures() 
 
     assert isinstance(breakdown, ProbeBreakdown)
     assert 0 <= breakdown.overall_score <= 1
-
-
-def test_score_matrix_row_breakdown_rejects_aggregate_only_matrix() -> None:
-    full_matrix = ClimateMatrix.from_cells((STUB_CLIMATE_CELLS[0],))
-    derived_only_matrix = ClimateMatrix(
-        latitudes=full_matrix.latitudes,
-        longitudes=full_matrix.longitudes,
-        temperature_c=None,
-        typical_highs_c=full_matrix.typical_highs_c,
-        hottest_month_highs_c=full_matrix.hottest_month_highs_c,
-        coldest_month_lows_c=full_matrix.coldest_month_lows_c,
-        median_precipitation_mm=full_matrix.median_precipitation_mm,
-        wettest_precipitation_mm=full_matrix.wettest_precipitation_mm,
-        average_cloud_cover_pct=full_matrix.average_cloud_cover_pct,
-        gloomiest_cloud_cover_pct=full_matrix.gloomiest_cloud_cover_pct,
-    )
-
-    with pytest.raises(ValueError, match="requires monthly climate arrays"):
-        score_matrix_row_breakdown(derived_only_matrix, 0, make_preferences())


### PR DESCRIPTION
## Summary
- remove low-value defensive checks from internal scoring and city-ranking runtime objects that are constructed only by our own code
- drop tests that intentionally corrupt those internal objects only to assert a specific validation exception
- remove stub-repository fixture tests that only proved returned objects had expected Python classes
- keep real validation at trust boundaries such as HTTP input, DuckDB reads, build-time database validation, and environment parsing

## Why
This started from `#91`, but the useful cleanup is not an exception-class swap. The problem was that some tests and constructors treated programmer-controlled runtime objects as if they were hostile input. That added noise, froze implementation details, and made internal corruption paths look like supported behavior.

The cache/vectorization work in `#39`, `#65`, and `#87` made these internal models more alignment-sensitive, so defensive guards were understandable while those paths stabilized. At this point the construction sites are narrow enough that normal NumPy/Python failures are sufficient if our own code corrupts an object. Boundary validation remains intact where malformed external data can actually enter.

I also did a broader pass for the same pattern. The remaining obvious brittle area is `tests/test_app_shell.py`, which over-specifies rendered markup and static script details. That is real, but it is a separate frontend contract-test cleanup rather than part of this internal runtime object audit.

## Testing
- `uv run pytest tests/test_scoring.py tests/test_climate_repository.py tests/test_score_service.py tests/test_heatmap.py -q`
- `uv run ruff check backend/scoring.py backend/cities.py backend/heatmap.py backend/climate_repository.py tests/test_scoring.py tests/test_climate_repository.py tests/test_score_service.py tests/test_heatmap.py`
- `uv run ty check backend tests/test_scoring.py tests/test_climate_repository.py tests/test_score_service.py tests/test_heatmap.py`

Closes #91
