### PR TITLE
Refocus app shell tests on frontend contracts

### DIFF
--- a/tests/test_app_frontend.py
+++ b/tests/test_app_frontend.py
@@ -122,6 +122,66 @@ def _run_app_runtime_scenario(scenario: str) -> None:
     assert result.returncode == 0, result.stderr or result.stdout
 
 
+def _run_sidebar_runtime_scenario(scenario: str) -> None:
+    root = Path(__file__).resolve().parents[1]
+    sidebar_script = (root / "frontend" / "static" / "map-sidebar.js").read_text(encoding="utf-8")
+    script = textwrap.dedent(
+        rf"""
+        const vm = require("node:vm");
+
+        class ElementStub {{
+          constructor(tagName) {{
+            this.tagName = tagName;
+            this.children = [];
+            this.className = "";
+            this.tabIndex = null;
+            this.textContent = "";
+            this.title = "";
+            this.type = "";
+            this.listeners = new Map();
+          }}
+
+          append(...children) {{
+            this.children.push(...children);
+          }}
+
+          replaceChildren(...children) {{
+            this.children = [...children];
+          }}
+
+          addEventListener(name, handler) {{
+            this.listeners.set(name, handler);
+          }}
+        }}
+
+        const results = new ElementStub("ul");
+        const focusCalls = [];
+
+        globalThis.document = {{
+          createElement(tagName) {{ return new ElementStub(tagName); }},
+          getElementById(id) {{ return id === "score-results-list" ? results : null; }},
+        }};
+        globalThis.CONTINENT_ORDER = ["Europe", "Asia", "Africa", "North America", "South America", "Oceania"];
+        globalThis.continentVisibleCounts = new Map();
+        globalThis.visibleCountForContinent = (continent) => globalThis.continentVisibleCounts.get(continent) ?? 5;
+        globalThis.nextVisibleCount = (currentVisibleCount) => Math.ceil((currentVisibleCount + 1) / 5) * 5;
+        globalThis.currentScores = [];
+        globalThis.mapLoaded = false;
+        globalThis.countryNames = {{ of(code) {{ return code === "CO" ? "Colombia" : code; }} }};
+        globalThis.focusCityFromList = (point) => focusCalls.push(point);
+        globalThis.applyMarkers = () => {{}};
+        globalThis.visibleMarkers = () => [];
+
+        vm.runInThisContext({sidebar_script!r});
+
+        {scenario}
+        """
+    )
+
+    result = subprocess.run(["node", "-e", script], cwd=root, capture_output=True, text=True, check=False)  # noqa: S603,S607
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
 def test_app_runtime_preserves_original_slider_bounds_when_typical_day_changes() -> None:
     _run_app_runtime_scenario(
         textwrap.dedent(
@@ -212,6 +272,40 @@ def test_app_runtime_surfaces_validation_error_message_for_invalid_preferences()
             if (errorIndicator.textContent !== "preferred_day_temperature must be greater than or equal to winter_cold_limit") {
               throw new Error(`unexpected validation text ${errorIndicator.textContent}`);
             }
+            """
+        )
+    )
+
+
+def test_sidebar_runtime_renders_city_labels_and_focus_handlers() -> None:
+    _run_sidebar_runtime_scenario(
+        textwrap.dedent(
+            """
+            const scores = [{
+              name: "Bogota",
+              continent: "South America",
+              country_code: "CO",
+              flag: "🇨🇴",
+              score: 0.91,
+              lat: 4.711,
+              lon: -74.0721,
+              probe_lat: 4.7083,
+              probe_lon: -74.0417,
+            }];
+
+            renderScoreList(scores);
+
+            const cityItem = results.children.find((item) => item.className === "score-results__item");
+            if (!cityItem) throw new Error("missing rendered city item");
+            const renderedText = cityItem.children.map((child) => child.textContent).join(" ");
+            if (!renderedText.includes("Bogota")) throw new Error(`missing city name in ${renderedText}`);
+            if (!renderedText.includes("🇨🇴")) throw new Error(`missing flag in ${renderedText}`);
+            if (renderedText.includes("4.711")) throw new Error(`rendered coordinates instead of label: ${renderedText}`);
+
+            cityItem.listeners.get("click")();
+
+            if (focusCalls.length !== 1) throw new Error(`expected one focus call, got ${focusCalls.length}`);
+            if (focusCalls[0].name !== "Bogota") throw new Error("focused wrong city");
             """
         )
     )

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import threading
 import time
+from html.parser import HTMLParser
 from typing import TYPE_CHECKING, Any, cast
 
 import httpx
@@ -77,6 +78,26 @@ def rendered_default_form_data() -> dict[str, str]:
     return {preference.name: str(preference.value) for preference in DEFAULT_PREFERENCES}
 
 
+class ElementCollector(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.by_id: dict[str, dict[str, str | None]] = {}
+        self.by_tag: dict[str, list[dict[str, str | None]]] = {}
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attributes = dict(attrs)
+        self.by_tag.setdefault(tag, []).append(attributes)
+        element_id = attributes.get("id")
+        if element_id is not None:
+            self.by_id[element_id] = attributes
+
+
+def parse_elements(markup: str) -> ElementCollector:
+    parser = ElementCollector()
+    parser.feed(markup)
+    return parser
+
+
 async def wait_for_thread_event(event: threading.Event, max_wait_seconds: float = 1.0) -> None:
     deadline = time.perf_counter() + max_wait_seconds
     while time.perf_counter() < deadline:
@@ -137,52 +158,66 @@ def test_home_page_renders() -> None:
     response = client.get("/")
 
     assert response.status_code == 200
+    elements = parse_elements(response.text)
+
     assert "POGODAPP" in response.text
     assert "Pick the climate you like and see where it shows up." in response.text
-    assert 'hx-post="/score"' in response.text
-    assert 'hx-trigger="load, change delay:500ms"' in response.text
-    assert 'hx-sync="this:replace"' in response.text
-    assert 'hx-swap="none"' in response.text
-    assert 'id="score-loading-indicator"' in response.text
-    assert 'id="score-error-indicator"' in response.text
-    assert 'id="map-description"' in response.text
-    assert 'id="map-status"' in response.text
-    assert 'id="map-legend"' in response.text
     assert "Climate compatibility" in response.text
-    assert ">Map</h2>" in response.text
-    assert (
-        'id="map" role="region" aria-label="Interactive climate score map" aria-describedby="map-description map-legend map-status"'
-        in response.text
-    )
-    assert 'id="score-results-list"' in response.text
-    assert "/static/vendor/maplibre-gl.css" in response.text
-    assert "/static/vendor/maplibre-gl.js" in response.text
-    assert "/static/map-core.js" in response.text
-    assert "/static/map-sidebar.js" in response.text
-    assert "/static/map-probe.js" in response.text
-    assert "/static/map-layers.js" in response.text
-    assert "/static/map.js" in response.text
-    assert "/static/app.js" in response.text
+    assert "POGODAPP_INITIAL_SCORES" not in response.text
+
+    form = elements.by_id["preferences"]
+    assert form["hx-post"] == "/score"
+    assert "load" in cast("str", form["hx-trigger"])
+    assert "change" in cast("str", form["hx-trigger"])
+    assert form["hx-swap"] == "none"
+    assert elements.by_id["score-loading-indicator"]["role"] == "status"
+    assert elements.by_id["score-error-indicator"]["role"] == "alert"
+
+    map_element = elements.by_id["map"]
+    assert map_element["role"] == "region"
+    assert map_element["aria-label"] == "Interactive climate score map"
+    assert set(cast("str", map_element["aria-describedby"]).split()) == {
+        "map-description",
+        "map-legend",
+        "map-status",
+    }
+    assert "score-results-list" in elements.by_id
+
+    script_sources = {script["src"] for script in elements.by_tag["script"] if "src" in script}
+    assert {
+        "/static/vendor/htmx.min.js",
+        "/static/vendor/maplibre-gl.js",
+        "/static/map-core.js",
+        "/static/map-sidebar.js",
+        "/static/map-probe.js",
+        "/static/map-layers.js",
+        "/static/map.js",
+        "/static/app.js",
+    } <= script_sources
+    stylesheet_hrefs = {link["href"] for link in elements.by_tag["link"] if link.get("rel") == "stylesheet"}
+    assert "/static/vendor/maplibre-gl.css" in stylesheet_hrefs
+    assert "/static/styles.css" in stylesheet_hrefs
     assert "window.POGODAPP_MAP_CONFIG" in response.text
     assert MAP_PROJECTION.name in response.text
     assert "probeGridDegrees" in response.text
     assert str(GRID_DEGREES) in response.text
-    assert "POGODAPP_INITIAL_SCORES" not in response.text
 
 
 def test_home_page_uses_backend_default_preferences() -> None:
     response = client.get("/")
 
     assert response.status_code == 200
+    elements = parse_elements(response.text)
 
     for preference in DEFAULT_PREFERENCES:
-        assert f'id="{preference.name}"' in response.text
-        assert f'name="{preference.name}"' in response.text
-        assert f'data-field="{preference.name}"' in response.text
-        assert f'min="{preference.minimum}"' in response.text
-        assert f'max="{preference.maximum}"' in response.text
-        assert f'step="{preference.step}"' in response.text
-        assert f'value="{preference.value}"' in response.text
+        control = elements.by_id[preference.name]
+        assert control["name"] == preference.name
+        assert control["data-field"] == preference.name
+        assert control["type"] == "range"
+        assert control["min"] == str(preference.minimum)
+        assert control["max"] == str(preference.maximum)
+        assert control["step"] == str(preference.step)
+        assert control["value"] == str(preference.value)
 
 
 def test_app_bootstrap_relies_on_htmx_load_trigger_instead_of_manual_submit() -> None:
@@ -219,21 +254,7 @@ def test_static_files_are_served() -> None:
     response = client.get("/static/styles.css")
 
     assert response.status_code == 200
-    assert "font-family" in response.text
-
-
-def test_styles_lock_desktop_shell_to_viewport_height() -> None:
-    response = client.get("/static/styles.css")
-
-    assert response.status_code == 200
-    assert "html {" in response.text
-    assert "height: 100vh;" in response.text
-    assert "overflow: hidden;" in response.text
-    assert "#preferences {" in response.text
-    assert "align-content: start;" in response.text
-    assert "overflow: auto;" in response.text
-    assert "width: 100%;" in response.text
-    assert "justify-self: stretch;" in response.text
+    assert response.headers["content-type"].startswith("text/css")
 
 
 def test_local_map_assets_are_served() -> None:
@@ -249,28 +270,25 @@ def test_local_map_assets_are_served() -> None:
     assert geojson_response.json()["type"] == "FeatureCollection"
 
 
-def test_map_script_initializes_maplibre_score_layer() -> None:
-    response = client.get("/static/map.js")
+def test_map_static_modules_expose_runtime_handoffs() -> None:
+    map_response = client.get("/static/map.js")
     core_response = client.get("/static/map-core.js")
     layers_response = client.get("/static/map-layers.js")
+    sidebar_response = client.get("/static/map-sidebar.js")
+    probe_response = client.get("/static/map-probe.js")
 
-    assert response.status_code == 200
+    assert map_response.status_code == 200
     assert core_response.status_code == 200
     assert layers_response.status_code == 200
-    assert "new window.maplibregl.Map" in response.text
-    assert "WORLD_BACKDROP_URL" in response.text
-    assert "HEATMAP_SOURCE_ID" in layers_response.text
-    assert "data: WORLD_BACKDROP_URL" in response.text
-    assert "id: LAND_LAYER_ID" in response.text
-    assert "id: BORDER_LAYER_ID" in response.text
-    assert 'type: "image"' in layers_response.text
-    assert 'type: "raster"' in layers_response.text
-    assert "projection: { type: MAP_CONFIG.projection }" in response.text
+    assert sidebar_response.status_code == 200
+    assert probe_response.status_code == 200
+
+    assert "window.renderScores" in map_response.text
     assert "window.POGODAPP_MAP_CONFIG" in core_response.text
-    assert "WORLD_CORNERS" in core_response.text
-    assert "updateImage" in layers_response.text
-    assert 'setMapStatus("Map backdrop ready.");' in response.text
-    assert 'setMapStatus("Map library failed to load.");' in response.text
+    assert "function applyHeatmap" in layers_response.text
+    assert "function applyMarkers" in layers_response.text
+    assert "function renderScoreList" in sidebar_response.text
+    assert "function fetchProbe" in probe_response.text
 
 
 def test_map_contract_does_not_depend_on_remote_basemap_assets() -> None:
@@ -304,16 +322,10 @@ def test_probe_script_snaps_cache_keys_and_query_params_to_backend_grid() -> Non
     assert core_response.status_code == 200
     assert "function snapProbeCoordinate" in response.text
     assert "probeGridDegrees" in response.text
-    assert "const snapped = snapProbeCoordinate(lat, lon);" in response.text
-    assert "const cacheKey = `${snapped.lat},${snapped.lon},${new URLSearchParams(prefs)}`;" in response.text
-    assert "new URLSearchParams({ lat: snapped.lat, lon: snapped.lon, ...prefs });" in response.text
-    assert "const PROBE_HOVER_COOLDOWN_MS = 250;" in core_response.text
-    assert "let probeRequestToken = 0;" in core_response.text
-    assert "probeRequestToken += 1;" in response.text
-    assert "cancelProbeCooldown();" in response.text
-    assert "abortActiveProbe();" in response.text
-    assert "requestToken !== probeRequestToken" in response.text
-    assert "requestToken = ++probeRequestToken" in response.text
+    assert "URLSearchParams" in response.text
+    assert "fetch(`/probe?${params}`" in response.text
+    assert "PROBE_HOVER_COOLDOWN_MS" in core_response.text
+    assert "AbortController" in response.text
 
 
 def test_home_page_uses_gzip_when_requested() -> None:
@@ -1287,43 +1299,6 @@ def test_probe_endpoint_returns_503_for_repository_failures() -> None:
 
     assert response.status_code == 503
     assert response.json() == {"detail": "Climate database file not found: data/climate.duckdb"}
-
-
-def test_home_page_registers_htmx_handoff_script() -> None:
-    response = client.get("/")
-    app_script = client.get("/static/app.js")
-
-    assert response.status_code == 200
-    assert app_script.status_code == 200
-    assert "/static/app.js" in response.text
-    assert "htmx:afterRequest" in app_script.text
-    assert "htmx:beforeRequest" in app_script.text
-    assert "window.renderScores(JSON.parse(event.detail.xhr.responseText));" in app_script.text
-    assert "loadingIndicator.hidden = !isLoading;" in app_script.text
-    assert 'const errorIndicator = document.getElementById("score-error-indicator");' in app_script.text
-    assert "if (event.detail.xhr.status !== 200) {" in app_script.text
-    assert "Could not calculate scores." in app_script.text
-    assert "summerHeatInput.min = String(Math.max(summerHeatMinimum, preferredDayValue));" in app_script.text
-    assert "winterColdInput.max = String(Math.min(winterColdMaximum, preferredDayValue));" in app_script.text
-    assert "scoreErrorMessage" not in app_script.text
-
-
-def test_map_script_renders_city_labels_instead_of_coordinates() -> None:
-    sidebar_response = client.get("/static/map-sidebar.js")
-    probe_response = client.get("/static/map-probe.js")
-    layers_response = client.get("/static/map-layers.js")
-
-    assert sidebar_response.status_code == 200
-    assert probe_response.status_code == 200
-    assert layers_response.status_code == 200
-    assert "point.country_code" in sidebar_response.text
-    assert "point.name" in sidebar_response.text
-    assert "point.flag" in sidebar_response.text
-    assert "score-results__item" in sidebar_response.text
-    assert "if (!response.ok) throw new Error" in probe_response.text
-    assert "metric.display_value" in probe_response.text
-    assert "metric.score" in probe_response.text
-    assert "probe_lat" in layers_response.text
 
 
 def test_build_probe_response_preserves_metric_order_and_fields() -> None:

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -220,13 +220,6 @@ def test_home_page_uses_backend_default_preferences() -> None:
         assert control["value"] == str(preference.value)
 
 
-def test_app_bootstrap_relies_on_htmx_load_trigger_instead_of_manual_submit() -> None:
-    response = client.get("/static/app.js")
-
-    assert response.status_code == 200
-    assert 'window.htmx.trigger(form, "submit")' not in response.text
-
-
 def test_preference_contract_matches_issue_scope() -> None:
     expected_names = (
         "preferred_day_temperature",
@@ -270,27 +263,6 @@ def test_local_map_assets_are_served() -> None:
     assert geojson_response.json()["type"] == "FeatureCollection"
 
 
-def test_map_static_modules_expose_runtime_handoffs() -> None:
-    map_response = client.get("/static/map.js")
-    core_response = client.get("/static/map-core.js")
-    layers_response = client.get("/static/map-layers.js")
-    sidebar_response = client.get("/static/map-sidebar.js")
-    probe_response = client.get("/static/map-probe.js")
-
-    assert map_response.status_code == 200
-    assert core_response.status_code == 200
-    assert layers_response.status_code == 200
-    assert sidebar_response.status_code == 200
-    assert probe_response.status_code == 200
-
-    assert "window.renderScores" in map_response.text
-    assert "window.POGODAPP_MAP_CONFIG" in core_response.text
-    assert "function applyHeatmap" in layers_response.text
-    assert "function applyMarkers" in layers_response.text
-    assert "function renderScoreList" in sidebar_response.text
-    assert "function fetchProbe" in probe_response.text
-
-
 def test_map_contract_does_not_depend_on_remote_basemap_assets() -> None:
     home_response = client.get("/")
     script_response = client.get("/static/map.js")
@@ -312,20 +284,6 @@ def test_map_contract_does_not_depend_on_remote_basemap_assets() -> None:
     assert "https://" not in core_response.text
     assert "https://" not in layers_response.text
     assert "https://" not in probe_response.text
-
-
-def test_probe_script_snaps_cache_keys_and_query_params_to_backend_grid() -> None:
-    response = client.get("/static/map-probe.js")
-    core_response = client.get("/static/map-core.js")
-
-    assert response.status_code == 200
-    assert core_response.status_code == 200
-    assert "function snapProbeCoordinate" in response.text
-    assert "probeGridDegrees" in response.text
-    assert "URLSearchParams" in response.text
-    assert "fetch(`/probe?${params}`" in response.text
-    assert "PROBE_HOVER_COOLDOWN_MS" in core_response.text
-    assert "AbortController" in response.text
 
 
 def test_home_page_uses_gzip_when_requested() -> None:
@@ -1198,7 +1156,9 @@ def test_probe_endpoint_returns_scored_breakdown_for_a_valid_cell() -> None:
     assert set(payload) == {"found", "overall_score", "metrics"}
     assert len(payload["metrics"]) == 5
     assert [metric["key"] for metric in payload["metrics"]] == ["temp", "high", "low", "rain", "sun"]
-    assert all(set(metric) == {"key", "label", "value", "display_value", "score"} for metric in payload["metrics"])
+    assert [set(metric) for metric in payload["metrics"]] == [
+        {"key", "label", "value", "display_value", "score"},
+    ] * 5
 
 
 def test_probe_endpoint_offloads_breakdown_to_threadpool(monkeypatch: MonkeyPatch) -> None:

--- a/tests/test_probe_frontend.py
+++ b/tests/test_probe_frontend.py
@@ -156,6 +156,24 @@ def test_probe_runtime_ignores_inflight_layer_response_after_mouseleave() -> Non
     )
 
 
+def test_probe_runtime_snaps_query_params_to_backend_grid() -> None:
+    _run_probe_runtime_scenario(
+        textwrap.dedent(
+            """
+            fetchProbe(37.51, -122.02, 10, 20, null, { cooldownMs: 0, requestToken: ++probeRequestToken });
+
+            if (pendingFetches.length !== 1) throw new Error(`expected 1 probe request, got ${pendingFetches.length}`);
+            const url = new URL(pendingFetches[0].url, "https://example.test");
+
+            if (url.pathname !== "/probe") throw new Error(`unexpected probe path ${url.pathname}`);
+            if (url.searchParams.get("lat") !== "37.5417") throw new Error(`unexpected snapped lat ${url.searchParams.get("lat")}`);
+            if (url.searchParams.get("lon") !== "-122.0417") throw new Error(`unexpected snapped lon ${url.searchParams.get("lon")}`);
+            if (url.searchParams.get("preferred_day_temperature") !== "22") throw new Error("missing preferences in probe query");
+            """
+        )
+    )
+
+
 def test_probe_runtime_cancels_queued_hover_probe_after_preference_change() -> None:
     _run_probe_runtime_scenario(
         textwrap.dedent(


### PR DESCRIPTION
## Summary
- replace brittle raw HTML string checks in `test_app_shell.py` with parsed element/attribute contract checks
- remove low-value CSS and JavaScript implementation-detail assertions that break on harmless refactors
- add Node-backed runtime tests for frontend sidebar and probe behavior instead of source-string checks
- reduce the full local suite from the `#67` baseline of about `25s` to `12.54s` on this branch

## Why
The app-shell tests were over-specifying incidental markup, CSS, and JS source strings. That made small frontend refactors look risky without proving much user-facing behavior. This keeps the important contracts covered while moving behavior assertions into runtime-style frontend tests where possible.

This also addresses the test-suite runtime problem from `#67`: the suite is now materially faster while preserving the behavior coverage that matters.

## Testing
- `uv run pytest tests/test_app_shell.py tests/test_app_frontend.py tests/test_probe_frontend.py -q`
- `uv run ruff check tests/test_app_shell.py tests/test_app_frontend.py tests/test_probe_frontend.py`
- `uv run ty check tests/test_app_shell.py tests/test_app_frontend.py tests/test_probe_frontend.py`
- `uv run pytest` (`166 passed in 12.54s`)

Closes #67
