### PR TITLE
Start heatmap loads before score results

### DIFF
--- a/frontend/static/app.js
+++ b/frontend/static/app.js
@@ -94,6 +94,14 @@ function bindPreferenceControls(form) {
   return syncAllControls;
 }
 
+function buildHeatmapUrl(form) {
+  const params = new URLSearchParams();
+  for (const input of form.querySelectorAll("input[type='range']")) {
+    params.set(input.name, input.value);
+  }
+  return `/heatmap?${params.toString()}`;
+}
+
 function bindScoreHandoff(form, syncControls) {
   const loadingIndicator = document.getElementById("score-loading-indicator");
   const errorIndicator = document.getElementById("score-error-indicator");
@@ -112,6 +120,9 @@ function bindScoreHandoff(form, syncControls) {
   document.body.addEventListener("htmx:beforeRequest", (event) => {
     if (event.detail.elt !== form) return;
     syncControls();
+    if (typeof window.renderHeatmap === "function") {
+      window.renderHeatmap(buildHeatmapUrl(form));
+    }
     setError("");
     setLoading(true);
   });

--- a/frontend/static/map-core.js
+++ b/frontend/static/map-core.js
@@ -56,6 +56,7 @@ const countryNames = typeof Intl.DisplayNames === "function"
   : null;
 let mapLoaded = false;
 let pendingResponse = null;
+let pendingHeatmapUrl = null;
 let probeTimer = null;
 let probeCooldownTimer = null;
 let probeController = null;

--- a/frontend/static/map.js
+++ b/frontend/static/map.js
@@ -11,6 +11,12 @@ function applyScoreResponse(scores, heatmapUrl) {
   setMapStatus(heatmapUrl ? `${scores.length} top matches shown.` : "No matches found.");
 }
 
+window.renderHeatmap = function renderHeatmap(heatmapUrl) {
+  pendingHeatmapUrl = heatmapUrl;
+  if (!map || !mapLoaded) return;
+  applyHeatmap(heatmapUrl || EMPTY_IMAGE);
+};
+
 function initializeMap() {
   const mapRoot = document.getElementById("map");
 
@@ -86,6 +92,10 @@ function initializeMap() {
 
     mapLoaded = true;
     setMapStatus("Map backdrop ready.");
+
+    if (pendingHeatmapUrl !== null) {
+      applyHeatmap(pendingHeatmapUrl || EMPTY_IMAGE);
+    }
 
     if (!pendingResponse) return;
 

--- a/tests/test_app_frontend.py
+++ b/tests/test_app_frontend.py
@@ -56,6 +56,7 @@ def _run_app_runtime_scenario(scenario: str) -> None:
         const bodyHandlers = new Map();
         const documentHandlers = new Map();
         const renderCalls = [];
+        const heatmapRenderCalls = [];
 
         const preferredDayInput = new HTMLInputElementStub("preferred_day_temperature", "preferred_day_temperature", -5, 35, 22, "preferred_day_temperature");
         const summerHeatInput = new HTMLInputElementStub("summer_heat_limit", "summer_heat_limit", -5, 42, 10, "summer_heat_limit");
@@ -104,6 +105,9 @@ def _run_app_runtime_scenario(scenario: str) -> None:
         }};
         globalThis.renderScores = (payload) => {{
           renderCalls.push(payload);
+        }};
+        globalThis.renderHeatmap = (heatmapUrl) => {{
+          heatmapRenderCalls.push(heatmapUrl);
         }};
 
         vm.runInThisContext({app_script!r});
@@ -250,6 +254,32 @@ def test_app_runtime_resyncs_temperature_controls_before_htmx_submit() -> None:
             if (summerHeatInput.value !== "18") throw new Error(`expected summer value clamped to 18, got ${summerHeatInput.value}`);
             if (winterColdInput.max !== "18") throw new Error(`expected winter max 18, got ${winterColdInput.max}`);
             if (winterColdInput.value !== "18") throw new Error(`expected winter value clamped to 18, got ${winterColdInput.value}`);
+            """
+        )
+    )
+
+
+def test_app_runtime_starts_heatmap_load_before_score_response() -> None:
+    _run_app_runtime_scenario(
+        textwrap.dedent(
+            """
+            preferredDayInput.value = "18";
+            summerHeatInput.value = "28";
+            winterColdInput.value = "2";
+            drynessInput.value = "40";
+            sunshineInput.value = "80";
+
+            triggerBody("htmx:beforeRequest", { elt: form });
+
+            if (heatmapRenderCalls.length !== 1) throw new Error(`expected one heatmap render call, got ${heatmapRenderCalls.length}`);
+            const heatmapUrl = heatmapRenderCalls[0];
+            if (!heatmapUrl.startsWith("/heatmap?")) throw new Error(`unexpected heatmap url ${heatmapUrl}`);
+            if (!heatmapUrl.includes("preferred_day_temperature=18")) throw new Error(`missing preferred temperature in ${heatmapUrl}`);
+            if (!heatmapUrl.includes("summer_heat_limit=28")) throw new Error(`missing summer limit in ${heatmapUrl}`);
+            if (!heatmapUrl.includes("winter_cold_limit=2")) throw new Error(`missing winter limit in ${heatmapUrl}`);
+            if (!heatmapUrl.includes("dryness_preference=40")) throw new Error(`missing dryness preference in ${heatmapUrl}`);
+            if (!heatmapUrl.includes("sunshine_preference=80")) throw new Error(`missing sunshine preference in ${heatmapUrl}`);
+            if (renderCalls.length !== 0) throw new Error("score response should not have rendered yet");
             """
         )
     )


### PR DESCRIPTION
## Summary
- Start loading `/heatmap` from `htmx:beforeRequest` using the current preference form values.
- Keep `POST /score` as the ranked-results request and render those results when the HTMX response arrives.
- Add frontend runtime coverage that proves the heatmap load starts before the `/score` response is rendered.

## Testing
- Commit hooks: `ruff check`, `ruff format`, `ty` type checker, `pytest`
- `uv run pytest tests/test_app_frontend.py tests/test_app_shell.py -q`
- `uv run ruff check frontend tests/test_app_frontend.py`

## Notes
- This is an experiment for VPS testing.
- It may duplicate score-field work when `GET /heatmap` beats `POST /score` to the backend cache.
- The thing to measure is whether faster heatmap start time is worth the possible extra CPU under slider churn.